### PR TITLE
Add opt-in Dub pack sync and community pack management

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,10 +172,11 @@ they first see its size and an **experimental sharing** warning. Nothing is
 offered until the host explicitly enables it. Anyone without that exact pack is
 then shown its name, size and the same warning, and chooses whether to download
 it from the host. Large transfers may be slow or cause disconnects on weaker
-connections. Declining does not kick them or install anything; the Download
-button remains available if they change their mind. The host sees who already
-has it, who declined, and each download's progress. **Begin dub** stays disabled
-until every connected player has verified the pack.
+connections. **Only accept packs from a host you trust.** Declining does not kick
+them or install anything; the Download button remains available if they change
+their mind. The host sees who already has it, who declined, and each download's
+progress. **Begin dub** stays disabled until every connected player has verified
+the pack.
 
 Received packs live in `%APPDATA%\YeahMaybe\ChoicerVoicer\multiplayer_pack_cache`
 and do not appear in the normal pack selector. A completed pack is reused by its

--- a/README.md
+++ b/README.md
@@ -251,13 +251,18 @@ Extras when that screen's layout can be identified safely. This is an in-game
 catalog, not an embedded web page: it fetches GameBanana's public JSON, the
 selected preview image and, only after you queue it, the selected archive.
 
-Installation is deliberately available only while you are out of an online
-lobby. Pick a submission, choose one of its files and press **Add to download
-queue**. Downloads run one at a time so several 200–450 MB archives do not fight
-over the same connection. You can queue more, cancel or retry them from
-**Downloads**, then close the browser and play any offline mode while the queue
-continues under the game's persistent Net autoload. A newly queued job waits if
-you are currently in online multiplayer.
+Pick a submission, choose one of its files and press **Add to download queue**.
+Downloads run one at a time so several 200–450 MB archives do not fight over the
+same connection. You can queue more, cancel or retry them from **Downloads**,
+then close the browser while the queue continues under the game's persistent Net
+autoload.
+
+By default, a newly queued job waits while you are in online multiplayer. The
+Downloads panel has a persistent **Allow downloads to start during online
+multiplayer** option for players who prefer otherwise. A large HTTPS transfer can
+still increase latency by saturating the connection even on a fast line, so the
+option defaults off. Turning it off never interrupts the active download; it only
+makes the next queued item wait until you leave online play.
 
 A successful install goes into the game's normal `packs_voice` folder, so it is
 available to the game and to host pack sharing. If a pack finishes while a pack

--- a/README.md
+++ b/README.md
@@ -74,8 +74,9 @@ installing it and getting a game going:
    [troubleshooting](#troubleshooting).
 3. Double click **Install.bat** and wait a few minutes. It'll ask you to
    install python first if you haven't got it.
-4. Copy the host's voice packs to everyone else (see
-   [setting up a game](#setting-up-a-game)).
+4. For the normal game show, copy the host's voice packs to everyone else (see
+   [setting up a game](#setting-up-a-game)). Dub mode can send its selected pack
+   from the host when somebody is missing it.
 5. Launch the new exe and click **ONLINE** in the top right of the main menu
    (or press **F9**), then host or join.
 
@@ -110,7 +111,7 @@ doesn't do that any more. See
 
 It downloads about 140mb of tools ([gdRE](https://github.com/GDRETools/gdsdecomp)
 and [Godot](https://godotengine.org), both free), builds the mod, and leaves
-`TheChoicerVoicer-Multiplayer-1.1.8.exe` sat in the same folder. Takes a few
+`TheChoicerVoicer-Multiplayer-1.2.0-dev.exe` sat in the same folder. Takes a few
 minutes. Run it again later and it reuses the downloads so it's quicker the
 second time.
 
@@ -151,9 +152,8 @@ python install_mod.py "C:\path\to\TheChoicerVoicer_0-5-1 stable.exe"
 
 ## setting up a game
 
-Everybody needs the same voice packs. This is the bit that trips people up, so
-do it before you try to play. Scores get worked out against the clips you're
-performing, so everyone needs the actual clip files the host picks.
+Everybody needs the clips used by the normal game show. Scores get worked out
+against those clips, so copy the host's voice packs before you play that mode.
 
 Copy the host's
 
@@ -164,8 +164,20 @@ Copy the host's
 folder over to everyone else, into the same place. Paste that path straight into
 explorer's address bar if you can't find it.
 
-The lobby lists anything it spots as different, and the mod would rather flat out
-refuse to start than let you desync halfway through a round.
+The lobby lists anything it spots as different, and the normal game show would
+rather flat out refuse to start than let you desync halfway through a round.
+
+Dub mode handles this differently. When the host presses Play on a dub pack,
+anyone without that exact pack is shown its name and size and chooses whether to
+download it from the host. Declining does not kick them or install anything; the
+Download button remains available if they change their mind. The host sees who
+already has it, who declined, and each download's progress. **Begin dub** stays
+disabled until every connected player has verified the pack.
+
+Received packs live in `%APPDATA%\YeahMaybe\ChoicerVoicer\multiplayer_pack_cache`
+and do not appear in the normal pack selector. A completed pack is reused by its
+content hash the next time it is selected, while an interrupted download resumes
+from the files already on disk.
 
 Everyone also needs the same build of the mod. If someone installed an older
 version they get kicked with a message saying so. Just get them to run the
@@ -185,8 +197,8 @@ name, not their real one. 2 to 4 players.
    one.
 2. Host hits **Host**. Everyone else types the host's IP in and hits **Join**.
 3. Once everyone's showing in the list, host hits **Start (choose clips)** for the
-   normal game show, or **Start (dub mode)**, picks a pack, and everyone gets
-   dragged into the match together.
+   normal game show, or **Start (dub mode)** and picks a pack. Anyone missing the
+   dub pack accepts the download; the host begins once everybody is ready.
 
 ### picking who you dub
 
@@ -382,6 +394,13 @@ acknowledged as they arrive now, which took another call, and they go over the
 wire compressed, so the audio itself is in a different shape too. Same story:
 right message on both screens, everybody rebuilds.
 
+v1.2.0-dev is on protocol 8. Dub mode identifies the selected pack by its file
+contents, offers it to anyone missing it, streams accepted downloads through the
+existing ENet connection with a bounded acknowledged window, verifies every file
+with SHA-256, and waits for the whole lobby before starting. The dub start packet
+now contains a content ID and relative clip paths rather than paths from the
+host's disk, so protocol 8 cannot play with earlier builds.
+
 **We were playing fine and then he just got kicked. No error, no crash, he was
 back at the menu.** That was a bug, fixed in v1.1.8, and it's the same 30 second
 ENet timeout as the two above with a different cause. A recording is about a
@@ -549,11 +568,18 @@ send one performance per turn, and stop everyone drifting apart between phases.
   means they're still recording, which can take as long as they like; a transfer
   that started and went quiet means the link died, and that gets 45 seconds. One
   combined limit couldn't tell those apart and skipped people for being slow.
+- Dub packs use a separate transfer node and reliable channel so adding its calls
+  cannot disturb the name-sorted join handshake. The manifest itself is paged;
+  pack files are streamed in 24KB chunks with at most 96KB unacknowledged per
+  client. Clients write straight to a resumable cache, reject unsafe paths and
+  executable formats, verify SHA-256 before reporting ready, and never hold a
+  whole video in memory.
 
 What's in `mod/`:
 
 ```
 mod/net/net_manager.gd            all the netcode, one autoload
+mod/net/pack_sync.gd              consent, cache and host-to-client dub packs
 mod/net/lobby.gd                  the lobby screen, built in code
 mod/net/dub_character_picker.gd   the casting screen, built in code
 mod/net/_selftest.gd              compiles every script in the project
@@ -564,8 +590,7 @@ mod/patches/v0_5_2/*.patch        the files that differ on 0.5.2
 mod/export_presets.cfg            the windows export preset
 ```
 
-Three new files and about 450 changed lines across 7 of the game's scripts. The
-installer reads `config/version` out of the decompiled project and picks the
+The installer reads `config/version` out of the decompiled project and picks the
 right patch set, so supporting a new build usually means one extra folder. It
 also fixes a gdRE bug where it writes node paths as `$A / B`, which every
 decompiled build needs sorting whether you're modding it or not.
@@ -591,9 +616,11 @@ godot --headless --path project -- host
 godot --headless --path project -- client
 ```
 
-`_nettest.gd` covers the bug that used to make the game unplayable after one
-pack. It runs a second show reusing the same contestant slot and barrier tags and
-checks the new take turns up instead of the old one.
+`_nettest.gd` runs a second show reusing the same contestant slot and barrier
+tags and checks the new take turns up instead of the old one. It also creates a
+throwaway dub pack larger than the transfer window: the client declines it,
+starts it on the second try, interrupts it after bytes reach disk, resumes and
+verifies it, and the host proves it did not continue until that was done.
 
 `devtest/old_peer/` is a project of its own, and needs no copy of the game. It
 connects to a host, says nothing at all, and leaves — which is exactly what a

--- a/README.md
+++ b/README.md
@@ -168,11 +168,14 @@ The lobby lists anything it spots as different, and the normal game show would
 rather flat out refuse to start than let you desync halfway through a round.
 
 Dub mode handles this differently. When the host presses Play on a dub pack,
-anyone without that exact pack is shown its name and size and chooses whether to
-download it from the host. Declining does not kick them or install anything; the
-Download button remains available if they change their mind. The host sees who
-already has it, who declined, and each download's progress. **Begin dub** stays
-disabled until every connected player has verified the pack.
+they first see its size and an **experimental sharing** warning. Nothing is
+offered until the host explicitly enables it. Anyone without that exact pack is
+then shown its name, size and the same warning, and chooses whether to download
+it from the host. Large transfers may be slow or cause disconnects on weaker
+connections. Declining does not kick them or install anything; the Download
+button remains available if they change their mind. The host sees who already
+has it, who declined, and each download's progress. **Begin dub** stays disabled
+until every connected player has verified the pack.
 
 Received packs live in `%APPDATA%\YeahMaybe\ChoicerVoicer\multiplayer_pack_cache`
 and do not appear in the normal pack selector. A completed pack is reused by its

--- a/README.md
+++ b/README.md
@@ -183,6 +183,12 @@ and do not appear in the normal pack selector. A completed pack is reused by its
 content hash the next time it is selected, while an interrupted download resumes
 from the files already on disk.
 
+Testing two copies on one computer normally finds the same installed packs and
+skips the transfer. Before enabling sharing, the host can tick **Force fresh
+download for testing**. That offer ignores the client's installed and cached
+copy, but still requires the client to accept it. If the forced transfer is
+interrupted, Retry resumes the new partial download instead of clearing it again.
+
 Everyone also needs the same build of the mod. If someone installed an older
 version they get kicked with a message saying so. Just get them to run the
 installer again.

--- a/README.md
+++ b/README.md
@@ -245,16 +245,25 @@ another one. No need to restart anything.
 ## community packs (experimental)
 
 The mod now has a native **Community Packs** screen for Dub Mode submissions on
-GameBanana. Open it from **Browse community packs** in the online screen. It also
-adds a **COMMUNITY PACKS** button to the game's Extras screen when that screen's
-layout can be identified safely. This is an in-game catalog, not an embedded web
-page: it fetches GameBanana's public JSON, the selected preview image and, only
-after you press Install, the selected archive.
+GameBanana. Open **COMMUNITY PACKS** directly from the normal main menu, or use
+**Browse community packs** in the online screen. The mod also tries to add it to
+Extras when that screen's layout can be identified safely. This is an in-game
+catalog, not an embedded web page: it fetches GameBanana's public JSON, the
+selected preview image and, only after you queue it, the selected archive.
 
 Installation is deliberately available only while you are out of an online
-lobby. Pick a submission, choose one of its files and press **Install pack**. A
-successful install goes into the game's normal `packs_voice` folder, so it is
-available to the game and to host pack sharing on the next lobby.
+lobby. Pick a submission, choose one of its files and press **Add to download
+queue**. Downloads run one at a time so several 200–450 MB archives do not fight
+over the same connection. You can queue more, cancel or retry them from
+**Downloads**, then close the browser and play any offline mode while the queue
+continues under the game's persistent Net autoload. A newly queued job waits if
+you are currently in online multiplayer.
+
+A successful install goes into the game's normal `packs_voice` folder, so it is
+available to the game and to host pack sharing. If a pack finishes while a pack
+selection screen is already open, leave and reopen that selector so the base
+game scans its folders again. Canceling an active download removes its partial
+file; retrying currently starts that archive from zero rather than resuming it.
 
 For the first version, the installer accepts ZIP files only. Before moving
 anything into `packs_voice`, it requires GameBanana's analysis and antivirus
@@ -272,9 +281,10 @@ media trustworthy. A malicious file could still target a bug in a media decoder.
 Only install packs from creators you trust. Content-rated submissions are hidden
 unless you explicitly enable them.
 
-There is no in-game update or uninstall flow yet. Delete an installed pack from
-`packs_voice` the same way you would any manually downloaded pack. RAR and 7z
-archives still need to be installed manually.
+An installed submission has an **Uninstall** button. It only removes a direct
+child of `packs_voice` carrying the matching manifest written by this installer;
+manually installed folders are deliberately left alone. There is no update flow
+yet. RAR and 7z archives still need to be installed manually.
 
 ## is this a virus
 
@@ -628,6 +638,7 @@ mod/net/pack_sync.gd              consent, cache and host-to-client dub packs
 mod/net/gamebanana_client.gd      GameBanana catalog and response normalization
 mod/net/community_pack_browser.gd native community catalog screen
 mod/net/community_pack_installer.gd staged, validated ZIP installation
+mod/net/community_pack_queue.gd    background queue, cancellation and retry
 mod/net/lobby.gd                  the lobby screen, built in code
 mod/net/dub_character_picker.gd   the casting screen, built in code
 mod/net/_selftest.gd              compiles every script in the project
@@ -690,11 +701,11 @@ against a clean decompile with the node path fix applied.
 
 - The lobby button is drawn over the menu by the mod rather than being a real
   menu entry, so it doesn't match the game's own styling.
-- The Community Packs button is inserted into Extras at runtime because the
-  purchased game's scene is not stored in this repository. The online-screen
-  link is the fallback if a future game build changes that menu layout.
-- The community installer supports ZIP archives only and has no update or
-  uninstall screen yet.
+- Extras integration is attempted at runtime because the purchased game's scene
+  is not stored here. The normal main-menu and online-screen buttons are the
+  reliable entry points if a future game build changes Extras.
+- The community installer supports ZIP archives only, has no update screen, and
+  restarts canceled downloads rather than resuming their partial files.
 - Windows 0.5.1 and 0.5.2 dev-2. Anything else fails with a clear error when it
   goes to patch it.
 - Everyone needs the same build. The mod checks and kicks you out with a message

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ you're dubbing and then watch the finished thing together.
   - [Command line options](#command-line-options)
 - [Setting up a game](#setting-up-a-game)
 - [Playing](#playing)
+- [Community packs (experimental)](#community-packs-experimental)
 - [Is this a virus](#is-this-a-virus)
 - [Troubleshooting](#troubleshooting)
 - [Why you cant just drop files in](#why-you-cant-just-drop-files-in)
@@ -240,6 +241,38 @@ note while it does. **Stop** goes out to everyone the same way.
 
 When the pack's finished you all get put back in the lobby and the host can pick
 another one. No need to restart anything.
+
+## community packs (experimental)
+
+The mod now has a native **Community Packs** screen for Dub Mode submissions on
+GameBanana. Open it from **Browse community packs** in the online screen. It also
+adds a **COMMUNITY PACKS** button to the game's Extras screen when that screen's
+layout can be identified safely. This is an in-game catalog, not an embedded web
+page: it fetches GameBanana's public JSON, the selected preview image and, only
+after you press Install, the selected archive.
+
+Installation is deliberately available only while you are out of an online
+lobby. Pick a submission, choose one of its files and press **Install pack**. A
+successful install goes into the game's normal `packs_voice` folder, so it is
+available to the game and to host pack sharing on the next lobby.
+
+For the first version, the installer accepts ZIP files only. Before moving
+anything into `packs_voice`, it requires GameBanana's analysis and antivirus
+checks to have passed, verifies the reported file size and MD5, checks the ZIP
+directory for traversal paths, links, encryption and expansion bombs, and
+extracts only the media, image and metadata formats a dub pack needs. Extraction
+happens in a temporary folder beside `packs_voice`, then the completed directory
+is renamed into place in one operation. Failed installs are removed rather than
+leaving half a pack behind.
+
+Those checks reduce the attack surface; they do not make arbitrary community
+media trustworthy. A malicious file could still target a bug in a media decoder.
+Only install packs from creators you trust. Content-rated submissions are hidden
+unless you explicitly enable them.
+
+There is no in-game update or uninstall flow yet. Delete an installed pack from
+`packs_voice` the same way you would any manually downloaded pack. RAR and 7z
+archives still need to be installed manually.
 
 ## is this a virus
 
@@ -590,6 +623,9 @@ What's in `mod/`:
 ```
 mod/net/net_manager.gd            all the netcode, one autoload
 mod/net/pack_sync.gd              consent, cache and host-to-client dub packs
+mod/net/gamebanana_client.gd      GameBanana catalog and response normalization
+mod/net/community_pack_browser.gd native community catalog screen
+mod/net/community_pack_installer.gd staged, validated ZIP installation
 mod/net/lobby.gd                  the lobby screen, built in code
 mod/net/dub_character_picker.gd   the casting screen, built in code
 mod/net/_selftest.gd              compiles every script in the project
@@ -652,6 +688,11 @@ against a clean decompile with the node path fix applied.
 
 - The lobby button is drawn over the menu by the mod rather than being a real
   menu entry, so it doesn't match the game's own styling.
+- The Community Packs button is inserted into Extras at runtime because the
+  purchased game's scene is not stored in this repository. The online-screen
+  link is the fallback if a future game build changes that menu layout.
+- The community installer supports ZIP archives only and has no update or
+  uninstall screen yet.
 - Windows 0.5.1 and 0.5.2 dev-2. Anything else fails with a clear error when it
   goes to patch it.
 - Everyone needs the same build. The mod checks and kicks you out with a message

--- a/README.md
+++ b/README.md
@@ -269,6 +269,11 @@ available to the game and to host pack sharing. If a pack finishes while a pack
 selection screen is already open, leave and reopen that selector so the base
 game scans its folders again. Canceling an active download removes its partial
 file; retrying currently starts that archive from zero rather than resuming it.
+The browser's **Installed** view lists every pack installed through this feature,
+including its creator, folder, install date and extracted size when available.
+You can uninstall it there without finding the GameBanana submission again.
+Only folders carrying this installer's matching manifest appear in the list or
+can be removed; manually installed packs remain untouched.
 
 For the first version, the installer accepts ZIP files only. Before moving
 anything into `packs_voice`, it requires GameBanana's analysis and antivirus

--- a/README.md
+++ b/README.md
@@ -263,7 +263,9 @@ directory for traversal paths, links, encryption and expansion bombs, and
 extracts only the media, image and metadata formats a dub pack needs. Extraction
 happens in a temporary folder beside `packs_voice`, then the completed directory
 is renamed into place in one operation. Failed installs are removed rather than
-leaving half a pack behind.
+leaving half a pack behind. If an archive puts every file directly at its ZIP
+root, the installer wraps those files in a generated pack folder instead of
+spilling them directly into `packs_voice`.
 
 Those checks reduce the attack surface; they do not make arbitrary community
 media trustworthy. A malicious file could still target a bug in a media decoder.

--- a/README.md
+++ b/README.md
@@ -275,10 +275,12 @@ You can uninstall it there without finding the GameBanana submission again.
 Only folders carrying this installer's matching manifest appear in the list or
 can be removed; manually installed packs remain untouched.
 
-For the first version, the installer accepts ZIP files only. Before moving
-anything into `packs_voice`, it requires GameBanana's analysis and antivirus
-checks to have passed, verifies the reported file size and MD5, checks the ZIP
-directory for traversal paths, links, encryption and expansion bombs, and
+For now, the installer accepts ZIP files only. RAR support needs a separate
+archive reader because Godot cannot inspect it itself; the browser explains this
+and prefers a ZIP automatically when a submission offers both formats. Before
+moving anything into `packs_voice`, it requires GameBanana's analysis and
+antivirus checks to have passed, verifies the reported file size and MD5, checks
+the ZIP directory for traversal paths, links, encryption and expansion bombs, and
 extracts only the media, image and metadata formats a dub pack needs. Extraction
 happens in a temporary folder beside `packs_voice`, then the completed directory
 is renamed into place in one operation. Failed installs are removed rather than

--- a/install_mod.py
+++ b/install_mod.py
@@ -697,7 +697,7 @@ def apply_mod(work: Path) -> None:
     say("mod", f"repaired {repair_node_paths(work)} decompiler node-path artifacts")
 
     shutil.copytree(MOD / "net", work / "net", dirs_exist_ok=True)
-    say("mod", "added multiplayer networking, lobby, dub casting and pack sync scripts")
+    say("mod", "added multiplayer, pack sharing and community pack browser scripts")
 
     count = 0
     for patch in patch_set_for(version):

--- a/install_mod.py
+++ b/install_mod.py
@@ -697,7 +697,7 @@ def apply_mod(work: Path) -> None:
     say("mod", f"repaired {repair_node_paths(work)} decompiler node-path artifacts")
 
     shutil.copytree(MOD / "net", work / "net", dirs_exist_ok=True)
-    say("mod", "added net/net_manager.gd, net/lobby.gd, net/dub_character_picker.gd")
+    say("mod", "added multiplayer networking, lobby, dub casting and pack sync scripts")
 
     count = 0
     for patch in patch_set_for(version):

--- a/mod/net/_nettest.gd
+++ b/mod/net/_nettest.gd
@@ -50,12 +50,46 @@ func _fake_take() -> AudioStreamWAV:
 	return w
 
 
+func _write_test_bytes(path: String, count: int, marker: int) -> void:
+	var data: PackedByteArray = []
+	data.resize(count)
+	for i: int in range(0, count, 997): data[i] = marker
+	var file: FileAccess = FileAccess.open(path, FileAccess.WRITE)
+	file.store_buffer(data)
+	file.close()
+
+
+func _write_test_text(path: String, text: String) -> void:
+	var file: FileAccess = FileAccess.open(path, FileAccess.WRITE)
+	file.store_string(text)
+	file.close()
+
+
+func _make_test_dub_pack() -> Dictionary:
+	var root: String = "user://packsync-nettest-source"
+	DirAccess.make_dir_recursive_absolute(root)
+	# More than PackSync.SEND_WINDOW so this cannot pass without at least one
+	# application acknowledgement opening the send window again.
+	_write_test_bytes(root.path_join("dub_video.ogv"), 1200000, 7)
+	_write_test_bytes(root.path_join("01_line.wav"), 90000, 11)
+	_write_test_text(root.path_join("01_line.ini"), "caption=Network test\ndub_timestamps=1.25\n")
+	_write_test_bytes(root.path_join("_backing_track.ogg"), 30000, 13)
+	_write_test_text(root.path_join("_pack_info.ini"),
+		"title=Network test\nbuild_nonce=%s-%d\n" % [
+			Time.get_datetime_string_from_system(true, true), Time.get_ticks_usec()])
+	return {"root": root, "clip": root.path_join("01_line.wav")}
+
+
 func _run_host() -> void:
 	print("NETTEST | hosting...")
+	Net.pack_sync.enable_test_automation(false, true)
 	var err: Error = Net.host_game("Hosty", "packA")
 	print("NETTEST | host_game err=%d" % err)
 
-	await get_tree().create_timer(4.0).timeout
+	# Give the second headless process enough time to start on a cold machine.
+	# Four seconds put the roster check and the join on the same frame and made
+	# this smoke test occasionally run its first round with the host alone.
+	await get_tree().create_timer(10.0).timeout
 	print("NETTEST | roster=%d slots=%s" % [Net.players.size(), str(Net.slot_map)])
 	if Net.manifests.size() == Net.players.size(): print("NETTEST PASS | host has a pack summary per player")
 	else: print("NETTEST FAIL | host has %d summaries for %d players" % [Net.manifests.size(), Net.players.size()])
@@ -86,6 +120,15 @@ func _run_host() -> void:
 
 	await Net.barrier("t1")
 	print("NETTEST | host cleared barrier again")
+
+	var test_pack: Dictionary = _make_test_dub_pack()
+	var prepared: Dictionary = await Net.prepare_dub_pack(
+		str(test_pack["root"]), PackedStringArray([str(test_pack["clip"])]))
+	if prepared.is_empty():
+		print("NETTEST FAIL | host pack preparation did not complete")
+	else:
+		print("NETTEST PASS | host waited until the client had the pack (%s)" % str(prepared["pack_id"]).left(12))
+		Net.pack_sync._cancel_host_offer("PackSync network test complete.")
 
 	Net.set_my_dub_characters(PackedStringArray(["Tuco"]))
 	await get_tree().create_timer(2.5).timeout
@@ -118,6 +161,8 @@ func _run_host() -> void:
 func _run_client() -> void:
 	await get_tree().create_timer(1.5).timeout
 	print("NETTEST | joining...")
+	Net.pack_sync.enable_test_automation(false, false)
+	Net.pack_sync.set_test_cache_root("user://packsync-nettest-client-cache")
 	var err: Error = Net.join_game("127.0.0.1", "Clienty", "packB")
 	print("NETTEST | join_game err=%d" % err)
 
@@ -148,6 +193,58 @@ func _run_client() -> void:
 
 	await Net.barrier("t1")
 	print("NETTEST | client cleared barrier again")
+
+	var received_pack: Array[String] = []
+	Net.pack_sync.pack_ready.connect(func(pack_id: String, path: String) -> void:
+		received_pack.assign([pack_id, path]))
+	var offer_waited: float = 0.0
+	while Net.pack_sync._client_state not in ["offered", "ready", "failed"] and offer_waited < 10.0:
+		await get_tree().process_frame
+		offer_waited += get_process_delta_time()
+	if Net.pack_sync._client_state == "offered":
+		Net.pack_sync.decline_download()
+		await get_tree().process_frame
+		if Net.pack_sync._client_state == "declined":
+			print("NETTEST PASS | client could decline the offered pack without losing it")
+		else:
+			print("NETTEST FAIL | client decline did not stick")
+		# Retry immediately, then interrupt once more after bytes are on disk. The
+		# second retry exercises both resume offsets and stale-chunk rejection.
+		Net.pack_sync.accept_download()
+		var partial_waited: float = 0.0
+		while (Net.pack_sync._client_state == "downloading"
+			and Net.pack_sync._client_received < 150000 and partial_waited < 5.0):
+			await get_tree().process_frame
+			partial_waited += get_process_delta_time()
+		if (Net.pack_sync._client_state == "downloading"
+			and Net.pack_sync._client_received < int(Net.pack_sync._active_offer["total_bytes"])):
+			var partial_bytes: int = Net.pack_sync._client_received
+			Net.pack_sync.decline_download()
+			await get_tree().process_frame
+			Net.pack_sync.accept_download()
+			if Net.pack_sync._client_received >= partial_bytes:
+				print("NETTEST PASS | interrupted pack download resumed from %d bytes" % partial_bytes)
+			else:
+				print("NETTEST FAIL | interrupted pack download restarted from zero")
+		else:
+			print("NETTEST FAIL | pack transfer finished before its resume path could be tested")
+	elif Net.pack_sync._client_state == "failed":
+		print("NETTEST FAIL | client rejected the pack offer: %s" % Net.pack_sync._client_error)
+	var pack_waited: float = 0.0
+	while received_pack.is_empty() and pack_waited < 20.0:
+		await get_tree().process_frame
+		pack_waited += get_process_delta_time()
+	if received_pack.is_empty():
+		print("NETTEST FAIL | client did not receive the offered pack")
+	else:
+		var received_root: String = received_pack[1]
+		var complete: bool = (
+			FileAccess.file_exists(received_root.path_join("dub_video.ogv"))
+			and FileAccess.file_exists(received_root.path_join("01_line.wav"))
+			and FileAccess.get_sha256(received_root.path_join("01_line.wav"))
+				== FileAccess.get_sha256("user://packsync-nettest-source/01_line.wav"))
+		if complete: print("NETTEST PASS | client cached and verified the streamed dub pack")
+		else: print("NETTEST FAIL | client pack cache is incomplete or corrupt")
 
 	Net.set_my_dub_characters(PackedStringArray(["Heisenberg"]))
 	await Net.dub_begin

--- a/mod/net/_nettest.gd
+++ b/mod/net/_nettest.gd
@@ -82,7 +82,7 @@ func _make_test_dub_pack() -> Dictionary:
 
 func _run_host() -> void:
 	print("NETTEST | hosting...")
-	Net.pack_sync.enable_test_automation(false, true)
+	Net.pack_sync.enable_test_automation(false, true, true)
 	var err: Error = Net.host_game("Hosty", "packA")
 	print("NETTEST | host_game err=%d" % err)
 
@@ -128,6 +128,10 @@ func _run_host() -> void:
 		print("NETTEST FAIL | host pack preparation did not complete")
 	else:
 		print("NETTEST PASS | host waited until the client had the pack (%s)" % str(prepared["pack_id"]).left(12))
+		if Net.pack_sync._panel_dismissed and not Net.pack_sync._panel.visible:
+			print("NETTEST PASS | pack-sharing panel stayed dismissed after Begin")
+		else:
+			print("NETTEST FAIL | pack-sharing panel remained visible after Begin")
 		Net.pack_sync._cancel_host_offer("PackSync network test complete.")
 
 	Net.set_my_dub_characters(PackedStringArray(["Tuco"]))
@@ -202,6 +206,16 @@ func _run_client() -> void:
 		await get_tree().process_frame
 		offer_waited += get_process_delta_time()
 	if Net.pack_sync._client_state == "offered":
+		if bool(Net.pack_sync._active_offer.get("force_download", false)):
+			var first_file: Dictionary = Net.pack_sync._active_offer["files"][0]
+			var seeded_root: String = "user://packsync-nettest-client-cache".path_join(
+				str(Net.pack_sync._active_offer["pack_id"]))
+			var seeded: String = seeded_root.path_join(str(first_file["path"]))
+			DirAccess.make_dir_recursive_absolute(seeded.get_base_dir())
+			_write_test_bytes(seeded, int(first_file["size"]), 99)
+			print("NETTEST PASS | host could force a fresh transfer for testing")
+		else:
+			print("NETTEST FAIL | test offer did not force a fresh transfer")
 		Net.pack_sync.decline_download()
 		await get_tree().process_frame
 		if Net.pack_sync._client_state == "declined":
@@ -211,6 +225,10 @@ func _run_client() -> void:
 		# Retry immediately, then interrupt once more after bytes are on disk. The
 		# second retry exercises both resume offsets and stale-chunk rejection.
 		Net.pack_sync.accept_download()
+		if Net.pack_sync._client_received == 0:
+			print("NETTEST PASS | forced transfer ignored the seeded cache file")
+		else:
+			print("NETTEST FAIL | forced transfer resumed the seeded cache file")
 		var partial_waited: float = 0.0
 		while (Net.pack_sync._client_state == "downloading"
 			and Net.pack_sync._client_received < 150000 and partial_waited < 5.0):

--- a/mod/net/_selftest.gd
+++ b/mod/net/_selftest.gd
@@ -21,9 +21,9 @@ func _ready() -> void:
 				failures.append(p)
 
 	print("SELFTEST | compiled %d scripts" % total)
+	_run_community_pack_tests(failures)
 	for f: String in failures:
 		print("SELFTEST FAIL | %s" % f)
-	_run_community_pack_tests(failures)
 	print("SELFTEST | %d failure(s)" % failures.size())
 	get_tree().quit()
 
@@ -112,8 +112,50 @@ func _run_community_pack_tests(failures: Array[String]) -> void:
 	else:
 		failures.append("could not create ZIP self-test fixture")
 	if FileAccess.file_exists(zip_path): DirAccess.remove_absolute(zip_path)
+	_test_flat_pack_archive(installer, failures)
 
 	if failures.is_empty(): print("SELFTEST PASS | community catalog and ZIP safety checks")
+
+
+func _test_flat_pack_archive(installer: Script, failures: Array[String]) -> void:
+	var zip_path: String = "user://community-pack-flat-selftest.zip"
+	var test_root: String = "user://community-pack-flat-selftest-packs"
+	if FileAccess.file_exists(zip_path): DirAccess.remove_absolute(zip_path)
+	var packer: = ZIPPacker.new()
+	if packer.open(zip_path) != OK:
+		failures.append("could not create flat ZIP self-test fixture")
+		return
+	for path: String in ["dub_video.ogv", "line.wav", "line.ini"]:
+		packer.start_file(path)
+		packer.write_file(PackedByteArray([4, 5, 6]))
+		packer.close_file()
+	packer.close()
+
+	var indexed: Dictionary = installer.inspect_zip(zip_path)
+	var entries: Array[Dictionary] = []
+	for value: Variant in Array(indexed.get("entries", [])):
+		if value is Dictionary: entries.append(value)
+	if indexed.has("error") or installer._find_dub_root(entries) != "":
+		failures.append("flat dub-pack ZIP detection")
+	else:
+		var result: Dictionary = installer._validate_and_extract(
+			zip_path,
+			{"id": 2147483645, "name": "Flat selftest pack", "author": "Selftest"},
+			{"id": 124, "name": "flat-fixture.zip", "md5": FileAccess.get_md5(zip_path)},
+			test_root,
+			false)
+		if result.has("error"):
+			failures.append("flat ZIP installation: %s" % str(result["error"]))
+		else:
+			var installed: String = str(result.get("path", ""))
+			if (installed == test_root or installed.get_base_dir() != test_root
+				or not FileAccess.file_exists(installed.path_join("dub_video.ogv"))
+				or FileAccess.file_exists(test_root.path_join("dub_video.ogv"))):
+				failures.append("flat ZIP files were not contained in their own pack folder")
+			_remove_test_tree(installed, test_root)
+	_remove_test_tree(test_root.path_join(".tcv-community-staging"), test_root)
+	DirAccess.remove_absolute(test_root)
+	if FileAccess.file_exists(zip_path): DirAccess.remove_absolute(zip_path)
 
 
 func _remove_test_tree(path: String, allowed_root: String) -> void:

--- a/mod/net/_selftest.gd
+++ b/mod/net/_selftest.gd
@@ -96,6 +96,12 @@ func _run_community_pack_tests(failures: Array[String]) -> void:
 		failures.append("GameBanana detail/file normalization")
 	elif not installer.installability_problem(detail_files[0]).is_empty():
 		failures.append("clean GameBanana ZIP was not installable")
+	if not installer.installability_problem({"name": "pack.rar"}).contains("RAR"):
+		failures.append("RAR archive guidance")
+	var long_name: String = "A".repeat(100) + ".rar"
+	var compact: String = load("res://net/community_pack_browser.gd")._compact_text(long_name, 40)
+	if compact.length() > 40 or not compact.ends_with(".rar") or not compact.contains("…"):
+		failures.append("community browser long-name compaction")
 
 	for unsafe: String in ["../outside.wav", "/absolute.wav", "C:/drive.wav", "ok/../outside.wav"]:
 		if installer._safe_relative_path(unsafe):

--- a/mod/net/_selftest.gd
+++ b/mod/net/_selftest.gd
@@ -201,6 +201,7 @@ func _run_download_queue_tests(failures: Array[String]) -> void:
 	add_child(fake_net)
 	queue.configure(fake_net)
 	add_child(queue)
+	queue.set_allow_online_downloads(false)
 	var mod: Dictionary = {"id": 42, "name": "Queue test"}
 	var invalid_file: Dictionary = {"id": 7, "name": "not-a-zip.rar", "size": 100}
 	var id: String = queue.enqueue(mod, invalid_file)
@@ -236,5 +237,15 @@ func _run_download_queue_tests(failures: Array[String]) -> void:
 	if (str(queue.get_job(failed_id).get("state", "")) != "failed"
 		or queue.active_count() != 0):
 		failures.append("failed download did not release the queue")
+	queue.dismiss(failed_id)
+	fake_net.online = true
+	queue.set_allow_online_downloads(true)
+	var online_id: String = queue.enqueue(
+		{"id": 44, "name": "Online opt-in"},
+		{"id": 8, "name": "still-not-a-zip.rar", "size": 100})
+	queue._pump()
+	if str(queue.get_job(online_id).get("state", "")) != "failed":
+		failures.append("online download opt-in did not release a queued job")
+	queue.set_allow_online_downloads(false)
 	queue.queue_free()
 	fake_net.queue_free()

--- a/mod/net/_selftest.gd
+++ b/mod/net/_selftest.gd
@@ -1,6 +1,21 @@
 extends Node
 # dev tool, not shipped. register as the last autoload to compile every .gd.
 
+class QueueTestNet:
+	extends Node
+	var online: bool = true
+	func is_online() -> bool: return online
+	func community_pack_library_changed() -> void: pass
+
+class QueueTestInstaller:
+	extends Node
+	signal failed(message: String)
+	var busy: bool = false
+	func is_busy() -> bool: return busy
+	func cancel() -> void:
+		busy = false
+		failed.emit("Download canceled.")
+
 func _ready() -> void:
 	var failures: Array[String] = []
 	var total: int = 0
@@ -22,6 +37,7 @@ func _ready() -> void:
 
 	print("SELFTEST | compiled %d scripts" % total)
 	_run_community_pack_tests(failures)
+	_run_download_queue_tests(failures)
 	for f: String in failures:
 		print("SELFTEST FAIL | %s" % f)
 	print("SELFTEST | %d failure(s)" % failures.size())
@@ -152,7 +168,10 @@ func _test_flat_pack_archive(installer: Script, failures: Array[String]) -> void
 				or not FileAccess.file_exists(installed.path_join("dub_video.ogv"))
 				or FileAccess.file_exists(test_root.path_join("dub_video.ogv"))):
 				failures.append("flat ZIP files were not contained in their own pack folder")
-			_remove_test_tree(installed, test_root)
+			var removed: Dictionary = installer._uninstall_path(
+				2147483645, installed, test_root, false)
+			if removed.has("error") or DirAccess.dir_exists_absolute(installed):
+				failures.append("guarded community-pack uninstall: %s" % str(removed))
 	_remove_test_tree(test_root.path_join(".tcv-community-staging"), test_root)
 	DirAccess.remove_absolute(test_root)
 	if FileAccess.file_exists(zip_path): DirAccess.remove_absolute(zip_path)
@@ -165,7 +184,57 @@ func _remove_test_tree(path: String, allowed_root: String) -> void:
 		return
 	var dir: DirAccess = DirAccess.open(path)
 	if dir == null: return
+	dir.include_hidden = true
 	for child: String in dir.get_directories():
 		_remove_test_tree(path.path_join(child), allowed_root)
 	for child: String in dir.get_files(): DirAccess.remove_absolute(path.path_join(child))
 	DirAccess.remove_absolute(path)
+
+
+func _run_download_queue_tests(failures: Array[String]) -> void:
+	var queue_script: Script = load("res://net/community_pack_queue.gd")
+	if queue_script == null:
+		failures.append("community download queue did not compile")
+		return
+	var fake_net: = QueueTestNet.new()
+	var queue: Node = queue_script.new()
+	add_child(fake_net)
+	queue.configure(fake_net)
+	add_child(queue)
+	var mod: Dictionary = {"id": 42, "name": "Queue test"}
+	var invalid_file: Dictionary = {"id": 7, "name": "not-a-zip.rar", "size": 100}
+	var id: String = queue.enqueue(mod, invalid_file)
+	if str(queue.get_job(id).get("state", "")) != "queued":
+		failures.append("download queue did not retain an online job")
+	queue.cancel(id)
+	if str(queue.get_job(id).get("state", "")) != "canceled":
+		failures.append("queued download cancellation")
+	queue.retry(id)
+	if str(queue.get_job(id).get("state", "")) != "queued":
+		failures.append("canceled download retry")
+	var real_installer: Node = queue.get("_installer")
+	var fake_installer: = QueueTestInstaller.new()
+	fake_installer.failed.connect(Callable(queue, "_on_failed"))
+	queue.add_child(fake_installer)
+	queue.set("_installer", fake_installer)
+	queue.set("_active_id", id)
+	var jobs: Array = queue.get("_jobs")
+	jobs[0]["state"] = "downloading"
+	fake_installer.busy = true
+	queue.cancel(id)
+	if (str(queue.get_job(id).get("state", "")) != "canceled"
+		or queue.active_count() != 0):
+		failures.append("active download cancellation did not release the queue")
+	queue.dismiss(id)
+	if not queue.get_job(id).is_empty(): failures.append("terminal download dismissal")
+	queue.set("_installer", real_installer)
+	fake_installer.queue_free()
+
+	fake_net.online = false
+	var failed_id: String = queue.enqueue({"id": 43, "name": "Bad archive"}, invalid_file)
+	queue._pump()
+	if (str(queue.get_job(failed_id).get("state", "")) != "failed"
+		or queue.active_count() != 0):
+		failures.append("failed download did not release the queue")
+	queue.queue_free()
+	fake_net.queue_free()

--- a/mod/net/_selftest.gd
+++ b/mod/net/_selftest.gd
@@ -168,6 +168,12 @@ func _test_flat_pack_archive(installer: Script, failures: Array[String]) -> void
 				or not FileAccess.file_exists(installed.path_join("dub_video.ogv"))
 				or FileAccess.file_exists(test_root.path_join("dub_video.ogv"))):
 				failures.append("flat ZIP files were not contained in their own pack folder")
+			var listed: Array[Dictionary] = installer.installed_packs(test_root)
+			if (listed.size() != 1 or str(listed[0].get("path", "")) != installed
+				or int(listed[0].get("mod_id", 0)) != 2147483645
+				or int(listed[0].get("installed_files", 0)) != 3
+				or int(listed[0].get("installed_bytes", 0)) != 9):
+				failures.append("installed community-pack library scan")
 			var removed: Dictionary = installer._uninstall_path(
 				2147483645, installed, test_root, false)
 			if removed.has("error") or DirAccess.dir_exists_absolute(installed):

--- a/mod/net/_selftest.gd
+++ b/mod/net/_selftest.gd
@@ -61,6 +61,18 @@ func _run_community_pack_tests(failures: Array[String]) -> void:
 	var page: Dictionary = client.parse_page_json(catalog_json, 3, true)
 	if int(page.get("page", 0)) != 3 or Array(page.get("records", [])).size() != 1:
 		failures.append("GameBanana catalog normalization/category filtering")
+	var search_url: String = client.build_search_url("movie night", 2)
+	if (search_url.contains("%%")
+		or not search_url.contains("_sSearchString=movie%20night")
+		or not search_url.contains("_csvFields=name%2Cdescription%2Cowner%2Ccredits")
+		or not search_url.ends_with("_nPage=2")):
+		failures.append("GameBanana search URL encoding")
+	var api_error: String = client._http_error_message(400, JSON.stringify({
+		"_sErrorCode": "INPUT_ERRORS",
+		"_aErrorData": {"_sSearchString": {"_sErrorMessage": "Must be 2 characters or more"}},
+	}))
+	if not api_error.contains("Must be 2 characters or more"):
+		failures.append("GameBanana API error details")
 
 	var detail_json: String = JSON.stringify({
 		"_idRow": 10,

--- a/mod/net/_selftest.gd
+++ b/mod/net/_selftest.gd
@@ -23,5 +23,107 @@ func _ready() -> void:
 	print("SELFTEST | compiled %d scripts" % total)
 	for f: String in failures:
 		print("SELFTEST FAIL | %s" % f)
+	_run_community_pack_tests(failures)
 	print("SELFTEST | %d failure(s)" % failures.size())
 	get_tree().quit()
+
+
+func _run_community_pack_tests(failures: Array[String]) -> void:
+	var client: Script = load("res://net/gamebanana_client.gd")
+	var installer: Script = load("res://net/community_pack_installer.gd")
+	if client == null or installer == null:
+		failures.append("community pack services did not compile")
+		return
+
+	var catalog_json: String = JSON.stringify({
+		"_aMetadata": {"_nRecordCount": 2, "_bIsComplete": true},
+		"_aRecords": [
+			{"_idRow": 10, "_sName": "Dub pack", "_aRootCategory": {"_sName": "Dub Mode"}},
+			{"_idRow": 11, "_sName": "Wrong category", "_aRootCategory": {"_sName": "Audio"}},
+		],
+	})
+	var page: Dictionary = client.parse_page_json(catalog_json, 3, true)
+	if int(page.get("page", 0)) != 3 or Array(page.get("records", [])).size() != 1:
+		failures.append("GameBanana catalog normalization/category filtering")
+
+	var detail_json: String = JSON.stringify({
+		"_idRow": 10,
+		"_sName": "Dub pack",
+		"_sText": "A <b>safe</b> description",
+		"_aFiles": [{
+			"_idRow": 99,
+			"_sFile": "dub-pack.zip",
+			"_sDownloadUrl": "https://gamebanana.com/dl/99",
+			"_nFilesize": 1024,
+			"_sMd5Checksum": "0123456789abcdef0123456789abcdef",
+			"_sAnalysisState": "done",
+			"_sAnalysisResult": "ok",
+			"_sAvState": "done",
+			"_sAvResult": "clean",
+		}],
+	})
+	var detail: Dictionary = client.parse_detail_json(detail_json)
+	var detail_files: Array = detail.get("files", [])
+	if detail_files.size() != 1 or str(detail.get("description", "")) != "A safe description":
+		failures.append("GameBanana detail/file normalization")
+	elif not installer.installability_problem(detail_files[0]).is_empty():
+		failures.append("clean GameBanana ZIP was not installable")
+
+	for unsafe: String in ["../outside.wav", "/absolute.wav", "C:/drive.wav", "ok/../outside.wav"]:
+		if installer._safe_relative_path(unsafe):
+			failures.append("unsafe archive path accepted: %s" % unsafe)
+
+	var zip_path: String = "user://community-pack-selftest.zip"
+	if FileAccess.file_exists(zip_path): DirAccess.remove_absolute(zip_path)
+	var packer: = ZIPPacker.new()
+	var zip_error: Error = packer.open(zip_path)
+	if zip_error == OK:
+		for path: String in ["wrapper/dub_video.ogv", "wrapper/line.wav", "wrapper/line.ini"]:
+			packer.start_file(path)
+			packer.write_file(PackedByteArray([1, 2, 3]))
+			packer.close_file()
+		packer.close()
+		var indexed: Dictionary = installer.inspect_zip(zip_path)
+		var entries: Array = indexed.get("entries", [])
+		if indexed.has("error") or entries.size() != 3:
+			failures.append("valid ZIP central directory inspection")
+		else:
+			var typed_entries: Array[Dictionary] = []
+			for value: Variant in entries:
+				if value is Dictionary: typed_entries.append(value)
+			if installer._find_dub_root(typed_entries) != "wrapper":
+				failures.append("dub root detection")
+			var test_root: String = "user://community-pack-selftest-packs"
+			var result: Dictionary = installer._validate_and_extract(
+				zip_path,
+				{"id": 2147483646, "name": "Selftest pack", "author": "Selftest"},
+				{"id": 123, "name": "fixture.zip", "md5": FileAccess.get_md5(zip_path)},
+				test_root,
+				false)
+			if result.has("error"):
+				failures.append("validated ZIP extraction: %s" % str(result["error"]))
+			else:
+				var installed: String = str(result.get("path", ""))
+				if not FileAccess.file_exists(installed.path_join("dub_video.ogv")):
+					failures.append("validated ZIP was not moved into packs_voice")
+				_remove_test_tree(installed, test_root)
+			_remove_test_tree(test_root.path_join(".tcv-community-staging"), test_root)
+			DirAccess.remove_absolute(test_root)
+	else:
+		failures.append("could not create ZIP self-test fixture")
+	if FileAccess.file_exists(zip_path): DirAccess.remove_absolute(zip_path)
+
+	if failures.is_empty(): print("SELFTEST PASS | community catalog and ZIP safety checks")
+
+
+func _remove_test_tree(path: String, allowed_root: String) -> void:
+	var prefix: String = allowed_root.trim_suffix("/") + "/"
+	if (path.is_empty() or not path.begins_with(prefix)
+		or not DirAccess.dir_exists_absolute(path)):
+		return
+	var dir: DirAccess = DirAccess.open(path)
+	if dir == null: return
+	for child: String in dir.get_directories():
+		_remove_test_tree(path.path_join(child), allowed_root)
+	for child: String in dir.get_files(): DirAccess.remove_absolute(path.path_join(child))
+	DirAccess.remove_absolute(path)

--- a/mod/net/community_pack_browser.gd
+++ b/mod/net/community_pack_browser.gd
@@ -54,6 +54,8 @@ var _downloads_button: Button
 var _downloads_modal: Control
 var _downloads_list: VBoxContainer
 var _download_summary: Label
+var _online_downloads_box: CheckBox
+var _downloads_note: Label
 var _uninstall_dialog: ConfirmationDialog
 
 
@@ -360,6 +362,15 @@ func _build_downloads_modal() -> void:
 	_download_summary.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
 	_download_summary.add_theme_color_override("font_color", MUTED)
 	column.add_child(_download_summary)
+	_online_downloads_box = CheckBox.new()
+	_online_downloads_box.text = "Allow downloads to start during online multiplayer"
+	_online_downloads_box.tooltip_text = (
+		"Large downloads can increase multiplayer latency. Active downloads are not stopped "
+		+ "when this is turned off.")
+	_online_downloads_box.add_theme_color_override("font_color", WARNING)
+	_online_downloads_box.toggled.connect(func(value: bool) -> void:
+		_downloads.set_allow_online_downloads(value))
+	column.add_child(_online_downloads_box)
 	var scroll: = ScrollContainer.new()
 	scroll.size_flags_vertical = Control.SIZE_EXPAND_FILL
 	scroll.horizontal_scroll_mode = ScrollContainer.SCROLL_MODE_DISABLED
@@ -368,12 +379,10 @@ func _build_downloads_modal() -> void:
 	_downloads_list.size_flags_horizontal = Control.SIZE_EXPAND_FILL
 	_downloads_list.add_theme_constant_override("separation", 8)
 	scroll.add_child(_downloads_list)
-	var note: = Label.new()
-	note.text = ("Downloads continue while this screen is closed and during offline play. "
-		+ "New queued downloads wait while you are in online multiplayer.")
-	note.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
-	note.add_theme_color_override("font_color", MUTED)
-	column.add_child(note)
+	_downloads_note = Label.new()
+	_downloads_note.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
+	_downloads_note.add_theme_color_override("font_color", MUTED)
+	column.add_child(_downloads_note)
 
 	_uninstall_dialog = ConfirmationDialog.new()
 	_uninstall_dialog.title = "Uninstall community pack?"
@@ -551,7 +560,7 @@ func _refresh_install_action() -> void:
 		_install_progress.value = clampi(
 			int(job.get("received", 0)), 0, int(_install_progress.max_value))
 		var status: String = str(job.get("status", "Queued"))
-		if state == "queued" and Net.is_online():
+		if state == "queued" and Net.is_online() and not _downloads.allow_online_downloads():
 			status = "Queued — waiting until you leave online multiplayer."
 		_install_status.text = status
 		_install_status.add_theme_color_override("font_color", MUTED)
@@ -569,12 +578,15 @@ func _refresh_install_action() -> void:
 	_install_progress.visible = false
 	_install_button.text = "Add to download queue"
 	_install_button.disabled = not problem.is_empty()
-	if Net.is_online():
-		_install_status.text = "This will wait in the queue until you leave online multiplayer."
-		_install_status.add_theme_color_override("font_color", WARNING)
-	elif not problem.is_empty():
+	if not problem.is_empty():
 		_install_status.text = problem
 		_install_status.add_theme_color_override("font_color", DANGER)
+	elif Net.is_online() and not _downloads.allow_online_downloads():
+		_install_status.text = "This will wait in the queue until you leave online multiplayer."
+		_install_status.add_theme_color_override("font_color", WARNING)
+	elif Net.is_online():
+		_install_status.text = "Ready to queue online. Large downloads may increase multiplayer latency."
+		_install_status.add_theme_color_override("font_color", WARNING)
 	else:
 		_install_status.text = "Ready to queue. Downloads continue during offline play."
 		_install_status.add_theme_color_override("font_color", MUTED)
@@ -594,6 +606,8 @@ func _on_install_pressed() -> void:
 
 func _on_downloads_changed() -> void:
 	if not is_instance_valid(_downloads_button): return
+	if is_instance_valid(_online_downloads_box):
+		_online_downloads_box.set_pressed_no_signal(_downloads.allow_online_downloads())
 	var active: int = _downloads.active_count()
 	_downloads_button.text = "Downloads (%d)" % active if active > 0 else "Downloads"
 	if is_instance_valid(_downloads_modal) and _downloads_modal.visible: _render_downloads()
@@ -613,7 +627,7 @@ func _update_selected_active_download() -> bool:
 	_install_progress.max_value = maxi(1, int(job.get("total", file.get("size", 0))))
 	_install_progress.value = clampi(int(job.get("received", 0)), 0, int(_install_progress.max_value))
 	_install_status.text = str(job.get("status", "Queued"))
-	if state == "queued" and Net.is_online():
+	if state == "queued" and Net.is_online() and not _downloads.allow_online_downloads():
 		_install_status.text = "Queued — waiting until you leave online multiplayer."
 	_install_status.add_theme_color_override("font_color", MUTED)
 	return true
@@ -632,7 +646,13 @@ func _render_downloads() -> void:
 	var jobs: Array[Dictionary] = _downloads.get_jobs()
 	var active: int = _downloads.active_count()
 	_download_summary.text = (
-		"%d active or queued. Downloads run one at a time to avoid saturating the connection." % active)
+		"%d active or queued. Downloads run one at a time to limit connection saturation." % active)
+	_downloads_note.text = (
+		"Downloads continue while this screen is closed. Online starts are enabled; turning "
+		+ "this off will not stop the active download, but the next queued item will wait."
+		if _downloads.allow_online_downloads()
+		else "Downloads continue while this screen is closed and during offline play. New queued "
+		+ "downloads wait while you are in online multiplayer unless you enable the option above.")
 	if jobs.is_empty():
 		var empty: = Label.new()
 		empty.text = "No downloads in this session."
@@ -659,7 +679,7 @@ func _render_downloads() -> void:
 		var state: String = str(job.get("state", "queued"))
 		var status: = Label.new()
 		status.text = str(job.get("status", state.capitalize()))
-		if state == "queued" and Net.is_online():
+		if state == "queued" and Net.is_online() and not _downloads.allow_online_downloads():
 			status.text = "Queued — waiting until online multiplayer closes"
 		if state == "failed" and not str(job.get("error", "")).is_empty():
 			status.text += " — " + str(job["error"])

--- a/mod/net/community_pack_browser.gd
+++ b/mod/net/community_pack_browser.gd
@@ -1,0 +1,596 @@
+extends Control
+# Native catalog UI. It is an overlay rather than a web view: only JSON, a
+# selected preview image and the chosen archive ever leave GameBanana.
+
+signal closed
+
+const CATALOG_SCRIPT: Script = preload("res://net/gamebanana_client.gd")
+const INSTALLER_SCRIPT: Script = preload("res://net/community_pack_installer.gd")
+
+const BG: Color = Color("080b14")
+const SURFACE: Color = Color("121827")
+const SURFACE_2: Color = Color("1a2234")
+const BORDER: Color = Color("34415d")
+const TEXT: Color = Color("f3f5fb")
+const MUTED: Color = Color("9ba7bd")
+const ACCENT: Color = Color("61c4ff")
+const WARNING: Color = Color("ffca58")
+const SUCCESS: Color = Color("63d69a")
+const DANGER: Color = Color("ff7b83")
+
+var _catalog: Node
+var _installer: Node
+var _image_http: HTTPRequest
+
+var _page: int = 1
+var _complete: bool = false
+var _query: String = ""
+var _records: Array[Dictionary] = []
+var _selected: Dictionary = {}
+var _detail: Dictionary = {}
+var _loading_detail: bool = false
+
+var _search: LineEdit
+var _sort: OptionButton
+var _rated: CheckBox
+var _page_label: Label
+var _list_status: Label
+var _list: VBoxContainer
+var _previous: Button
+var _next: Button
+
+var _preview: TextureRect
+var _preview_placeholder: Label
+var _detail_title: Label
+var _detail_meta: Label
+var _detail_description: Label
+var _file_picker: OptionButton
+var _install_status: Label
+var _install_progress: ProgressBar
+var _install_button: Button
+var _open_button: Button
+
+
+func _ready() -> void:
+	set_anchors_and_offsets_preset(Control.PRESET_TOP_LEFT)
+	_fit_to_viewport()
+	get_viewport().size_changed.connect(_fit_to_viewport)
+	mouse_filter = Control.MOUSE_FILTER_STOP
+	_build_ui()
+	_catalog = CATALOG_SCRIPT.new()
+	_catalog.page_loaded.connect(_on_page_loaded)
+	_catalog.detail_loaded.connect(_on_detail_loaded)
+	_catalog.request_failed.connect(_on_request_failed)
+	add_child(_catalog)
+	_installer = INSTALLER_SCRIPT.new()
+	_installer.progress.connect(_on_install_progress)
+	_installer.finished.connect(_on_install_finished)
+	_installer.failed.connect(_on_install_failed)
+	add_child(_installer)
+	_image_http = HTTPRequest.new()
+	_image_http.use_threads = true
+	_image_http.timeout = 12.0
+	_image_http.body_size_limit = 12 * 1024 * 1024
+	_image_http.request_completed.connect(_on_image_loaded)
+	add_child(_image_http)
+	_load_page()
+
+
+func _fit_to_viewport() -> void:
+	position = Vector2.ZERO
+	size = get_viewport_rect().size
+
+
+func _exit_tree() -> void:
+	if is_instance_valid(_catalog): _catalog.cancel()
+	if is_instance_valid(_installer) and _installer.is_busy(): _installer.cancel()
+	if is_instance_valid(_image_http): _image_http.cancel_request()
+
+
+func _unhandled_input(event: InputEvent) -> void:
+	if event.is_action_pressed("ui_cancel") and not _installer.is_busy():
+		get_viewport().set_input_as_handled()
+		closed.emit()
+
+
+func _build_ui() -> void:
+	var backdrop: = ColorRect.new()
+	backdrop.color = BG
+	backdrop.set_anchors_and_offsets_preset(Control.PRESET_FULL_RECT)
+	add_child(backdrop)
+
+	var margin: = MarginContainer.new()
+	margin.set_anchors_and_offsets_preset(Control.PRESET_FULL_RECT)
+	for side: String in ["left", "right", "top", "bottom"]:
+		margin.add_theme_constant_override("margin_" + side, 28)
+	add_child(margin)
+
+	var main: = VBoxContainer.new()
+	main.add_theme_constant_override("separation", 16)
+	margin.add_child(main)
+
+	var header: = HBoxContainer.new()
+	header.add_theme_constant_override("separation", 12)
+	main.add_child(header)
+	var heading_box: = VBoxContainer.new()
+	heading_box.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	header.add_child(heading_box)
+	var heading: = Label.new()
+	heading.text = "COMMUNITY PACKS"
+	heading.add_theme_font_size_override("font_size", 30)
+	heading.add_theme_color_override("font_color", TEXT)
+	heading_box.add_child(heading)
+	var subheading: = Label.new()
+	subheading.text = "Browse and install Dub Mode packs without leaving the game"
+	subheading.add_theme_font_size_override("font_size", 14)
+	subheading.add_theme_color_override("font_color", MUTED)
+	heading_box.add_child(subheading)
+	var source: = Label.new()
+	source.text = "  GAMEBANANA  •  DUB MODE  "
+	source.add_theme_font_size_override("font_size", 13)
+	source.add_theme_color_override("font_color", ACCENT)
+	header.add_child(source)
+	var close: Button = _button("Close", false)
+	close.pressed.connect(func() -> void:
+		if not _installer.is_busy(): closed.emit())
+	header.add_child(close)
+
+	var tools: = HBoxContainer.new()
+	tools.add_theme_constant_override("separation", 10)
+	main.add_child(tools)
+	_search = LineEdit.new()
+	_search.placeholder_text = "Search dub packs, creators or descriptions..."
+	_search.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	_search.custom_minimum_size.y = 40
+	_search.text_submitted.connect(func(text: String) -> void:
+		_query = text.strip_edges()
+		_page = 1
+		_load_page())
+	tools.add_child(_search)
+	var search_button: Button = _button("Search", true)
+	search_button.pressed.connect(func() -> void:
+		_query = _search.text.strip_edges()
+		_page = 1
+		_load_page())
+	tools.add_child(search_button)
+	_sort = OptionButton.new()
+	_sort.add_item("Newest")
+	_sort.set_item_metadata(0, "Generic_Newest")
+	_sort.add_item("Recently updated")
+	_sort.set_item_metadata(1, "Generic_LatestModified")
+	_sort.add_item("Most downloaded")
+	_sort.set_item_metadata(2, "Generic_MostDownloaded")
+	_sort.add_item("Most liked")
+	_sort.set_item_metadata(3, "Generic_MostLiked")
+	_sort.tooltip_text = "Sorting applies while browsing. Searches are ordered by relevance."
+	_sort.item_selected.connect(func(_index: int) -> void:
+		_page = 1
+		_load_page())
+	tools.add_child(_sort)
+	_rated = CheckBox.new()
+	_rated.text = "Include content-rated"
+	_rated.tooltip_text = "Content-rated packs are hidden by default."
+	_rated.toggled.connect(func(_on: bool) -> void: _render_list())
+	tools.add_child(_rated)
+	var refresh: Button = _button("Refresh", false)
+	refresh.pressed.connect(func() -> void: _load_page(true))
+	tools.add_child(refresh)
+
+	var split: = HSplitContainer.new()
+	split.size_flags_vertical = Control.SIZE_EXPAND_FILL
+	split.split_offset = 480
+	main.add_child(split)
+
+	var left_panel: = PanelContainer.new()
+	left_panel.custom_minimum_size.x = 420
+	left_panel.add_theme_stylebox_override("panel", _box(SURFACE, 12, BORDER, 1))
+	split.add_child(left_panel)
+	var left_margin: = MarginContainer.new()
+	for side: String in ["left", "right", "top", "bottom"]:
+		left_margin.add_theme_constant_override("margin_" + side, 14)
+	left_panel.add_child(left_margin)
+	var left: = VBoxContainer.new()
+	left.add_theme_constant_override("separation", 10)
+	left_margin.add_child(left)
+	_list_status = Label.new()
+	_list_status.add_theme_color_override("font_color", MUTED)
+	left.add_child(_list_status)
+	var scroll: = ScrollContainer.new()
+	scroll.size_flags_vertical = Control.SIZE_EXPAND_FILL
+	scroll.horizontal_scroll_mode = ScrollContainer.SCROLL_MODE_DISABLED
+	left.add_child(scroll)
+	_list = VBoxContainer.new()
+	_list.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	_list.add_theme_constant_override("separation", 7)
+	scroll.add_child(_list)
+	var paging: = HBoxContainer.new()
+	paging.alignment = BoxContainer.ALIGNMENT_CENTER
+	paging.add_theme_constant_override("separation", 10)
+	left.add_child(paging)
+	_previous = _button("Previous", false)
+	_previous.pressed.connect(func() -> void:
+		if _page > 1:
+			_page -= 1
+			_load_page())
+	paging.add_child(_previous)
+	_page_label = Label.new()
+	_page_label.custom_minimum_size.x = 100
+	_page_label.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
+	paging.add_child(_page_label)
+	_next = _button("Next", false)
+	_next.pressed.connect(func() -> void:
+		if not _complete:
+			_page += 1
+			_load_page())
+	paging.add_child(_next)
+
+	var right_panel: = PanelContainer.new()
+	right_panel.custom_minimum_size.x = 400
+	right_panel.add_theme_stylebox_override("panel", _box(SURFACE, 12, BORDER, 1))
+	split.add_child(right_panel)
+	var right_margin: = MarginContainer.new()
+	for side: String in ["left", "right", "top", "bottom"]:
+		right_margin.add_theme_constant_override("margin_" + side, 18)
+	right_panel.add_child(right_margin)
+	var detail_scroll: = ScrollContainer.new()
+	detail_scroll.horizontal_scroll_mode = ScrollContainer.SCROLL_MODE_DISABLED
+	right_margin.add_child(detail_scroll)
+	var detail: = VBoxContainer.new()
+	detail.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	detail.add_theme_constant_override("separation", 10)
+	detail_scroll.add_child(detail)
+	var preview_panel: = PanelContainer.new()
+	preview_panel.custom_minimum_size = Vector2(400, 170)
+	preview_panel.add_theme_stylebox_override("panel", _box(SURFACE_2, 8, BORDER, 1))
+	detail.add_child(preview_panel)
+	_preview = TextureRect.new()
+	_preview.expand_mode = TextureRect.EXPAND_IGNORE_SIZE
+	_preview.stretch_mode = TextureRect.STRETCH_KEEP_ASPECT_CENTERED
+	preview_panel.add_child(_preview)
+	_preview_placeholder = Label.new()
+	_preview_placeholder.text = "SELECT A PACK TO PREVIEW"
+	_preview_placeholder.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
+	_preview_placeholder.vertical_alignment = VERTICAL_ALIGNMENT_CENTER
+	_preview_placeholder.add_theme_font_size_override("font_size", 13)
+	_preview_placeholder.add_theme_color_override("font_color", MUTED)
+	preview_panel.add_child(_preview_placeholder)
+	_detail_title = Label.new()
+	_detail_title.text = "Choose a pack"
+	_detail_title.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
+	_detail_title.add_theme_font_size_override("font_size", 24)
+	_detail_title.add_theme_color_override("font_color", TEXT)
+	detail.add_child(_detail_title)
+	_detail_meta = Label.new()
+	_detail_meta.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
+	_detail_meta.add_theme_color_override("font_color", MUTED)
+	detail.add_child(_detail_meta)
+	_detail_description = Label.new()
+	_detail_description.text = "Select a result to see its files and installation status."
+	_detail_description.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
+	detail.add_child(_detail_description)
+	var file_label: = Label.new()
+	file_label.text = "Download file"
+	file_label.add_theme_font_size_override("font_size", 14)
+	file_label.add_theme_color_override("font_color", MUTED)
+	detail.add_child(file_label)
+	_file_picker = OptionButton.new()
+	_file_picker.disabled = true
+	_file_picker.item_selected.connect(func(_index: int) -> void: _refresh_install_action())
+	detail.add_child(_file_picker)
+	_install_progress = ProgressBar.new()
+	_install_progress.visible = false
+	_install_progress.show_percentage = true
+	detail.add_child(_install_progress)
+	_install_status = Label.new()
+	_install_status.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
+	_install_status.add_theme_color_override("font_color", MUTED)
+	detail.add_child(_install_status)
+	var detail_buttons: = HBoxContainer.new()
+	detail_buttons.add_theme_constant_override("separation", 8)
+	detail.add_child(detail_buttons)
+	_install_button = _button("Install pack", true)
+	_install_button.disabled = true
+	_install_button.pressed.connect(_on_install_pressed)
+	detail_buttons.add_child(_install_button)
+	_open_button = _button("Open on GameBanana", false)
+	_open_button.disabled = true
+	_open_button.pressed.connect(func() -> void:
+		var url: String = str(_selected.get("profile_url", ""))
+		if url.begins_with("https://gamebanana.com/"): OS.shell_open(url))
+	detail_buttons.add_child(_open_button)
+	var caution: = Label.new()
+	caution.text = ("Downloads are community content. ZIPs are staged and checked before installation, "
+		+ "but only install packs from creators you trust.")
+	caution.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
+	caution.add_theme_color_override("font_color", WARNING)
+	detail.add_child(caution)
+
+
+func _load_page(force: bool = false) -> void:
+	if not is_instance_valid(_catalog) or _catalog.is_busy(): return
+	_loading_detail = false
+	_set_list_busy(true)
+	_records.clear()
+	_render_list()
+	if _query.is_empty():
+		_catalog.fetch_page(_page, str(_sort.get_item_metadata(_sort.selected)), force)
+	else:
+		_catalog.search(_query, _page, "best_match", force)
+
+
+func _set_list_busy(busy: bool) -> void:
+	_search.editable = not busy
+	_sort.disabled = busy or not _query.is_empty()
+	_previous.disabled = busy or _page <= 1
+	_next.disabled = busy or _complete
+	if busy: _list_status.text = "Loading from GameBanana..."
+
+
+func _on_page_loaded(payload: Dictionary) -> void:
+	_loading_detail = false
+	_page = int(payload.get("page", _page))
+	_complete = bool(payload.get("complete", false))
+	_records.clear()
+	for value: Variant in Array(payload.get("records", [])):
+		if value is Dictionary: _records.append(value)
+	_set_list_busy(false)
+	_page_label.text = "Page %d" % _page
+	_previous.disabled = _page <= 1
+	_next.disabled = _complete
+	var total: int = int(payload.get("total", 0))
+	_list_status.text = "%s%d dub pack%s" % [
+		"About " if not _complete else "", total, "" if total == 1 else "s"]
+	_render_list()
+
+
+func _render_list() -> void:
+	for child: Node in _list.get_children():
+		_list.remove_child(child)
+		child.queue_free()
+	var shown: int = 0
+	var hidden: int = 0
+	for record: Dictionary in _records:
+		if bool(record.get("content_rated", false)) and not _rated.button_pressed:
+			hidden += 1
+			continue
+		shown += 1
+		var row: Button = Button.new()
+		row.alignment = HORIZONTAL_ALIGNMENT_LEFT
+		row.custom_minimum_size.y = 68
+		row.text_overrun_behavior = TextServer.OVERRUN_TRIM_ELLIPSIS
+		var category: String = str(record.get("subcategory", ""))
+		if category.is_empty(): category = str(record.get("category", "Dub Mode"))
+		if category.is_empty(): category = "Dub Mode"
+		var warning: String = "  •  CONTENT-RATED" if bool(record.get("content_rated", false)) else ""
+		row.text = "%s\nby %s  •  %s%s" % [record["name"], record["author"], category, warning]
+		row.tooltip_text = str(record.get("name", ""))
+		row.add_theme_font_size_override("font_size", 15)
+		row.add_theme_color_override("font_color", TEXT)
+		row.add_theme_color_override("font_hover_color", TEXT)
+		row.add_theme_stylebox_override("normal", _box(SURFACE_2, 8, Color.TRANSPARENT, 0))
+		row.add_theme_stylebox_override("hover", _box(Color("25304a"), 8, ACCENT, 1))
+		row.add_theme_stylebox_override("pressed", _box(Color("202c45"), 8, ACCENT, 2))
+		row.pressed.connect(_select_record.bind(record))
+		_list.add_child(row)
+	if shown == 0 and not _records.is_empty():
+		var empty: = Label.new()
+		empty.text = "%d content-rated result(s) hidden. Enable the checkbox above to show them." % hidden
+		empty.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
+		empty.add_theme_color_override("font_color", MUTED)
+		_list.add_child(empty)
+	elif shown == 0 and not _catalog.is_busy():
+		var empty: = Label.new()
+		empty.text = "No Dub Mode packs were found on this page."
+		empty.add_theme_color_override("font_color", MUTED)
+		_list.add_child(empty)
+
+
+func _select_record(record: Dictionary) -> void:
+	if _installer.is_busy() or _catalog.is_busy(): return
+	_loading_detail = true
+	_selected = record.duplicate(true)
+	_detail.clear()
+	_preview.texture = null
+	_preview_placeholder.visible = true
+	_detail_title.text = str(record.get("name", "Dub pack"))
+	_detail_meta.text = "by %s  •  Loading details..." % str(record.get("author", "Unknown creator"))
+	_detail_description.text = "Loading description and download files..."
+	_file_picker.clear()
+	_file_picker.disabled = true
+	_install_status.text = ""
+	_install_button.disabled = true
+	_open_button.disabled = false
+	_catalog.fetch_detail(int(record.get("id", 0)))
+	_load_preview(str(record.get("image_url", "")))
+
+
+func _on_detail_loaded(detail: Dictionary) -> void:
+	_loading_detail = false
+	if int(detail.get("id", 0)) != int(_selected.get("id", 0)): return
+	for key: Variant in _selected:
+		if not detail.has(key) or str(detail.get(key, "")).is_empty(): detail[key] = _selected[key]
+	_detail = detail
+	_detail_title.text = str(detail.get("name", "Dub pack"))
+	var parts: PackedStringArray = ["by %s" % str(detail.get("author", "Unknown creator"))]
+	if not str(detail.get("subcategory", "")).is_empty(): parts.append(str(detail["subcategory"]))
+	if not str(detail.get("version", "")).is_empty(): parts.append("version %s" % str(detail["version"]))
+	if bool(detail.get("content_rated", false)): parts.append("CONTENT-RATED")
+	_detail_meta.text = "  •  ".join(parts)
+	_detail_meta.add_theme_color_override(
+		"font_color", WARNING if bool(detail.get("content_rated", false)) else MUTED)
+	var description: String = str(detail.get("description", ""))
+	_detail_description.text = description if not description.is_empty() else "No description was provided."
+	_file_picker.clear()
+	for file_value: Variant in Array(detail.get("files", [])):
+		if not file_value is Dictionary: continue
+		var file: Dictionary = file_value
+		_file_picker.add_item("%s  —  %s" % [file["name"], _format_bytes(int(file["size"]))])
+		_file_picker.set_item_metadata(_file_picker.item_count - 1, file)
+	_file_picker.disabled = _file_picker.item_count == 0
+	if _file_picker.item_count > 0:
+		var first_zip: int = 0
+		for i: int in _file_picker.item_count:
+			var candidate: Dictionary = _file_picker.get_item_metadata(i)
+			if str(candidate.get("name", "")).get_extension().to_lower() == "zip":
+				first_zip = i
+				break
+		_file_picker.select(first_zip)
+	_refresh_install_action()
+
+
+func _selected_file() -> Dictionary:
+	if _file_picker.item_count == 0 or _file_picker.selected < 0: return {}
+	var value: Variant = _file_picker.get_item_metadata(_file_picker.selected)
+	return value if value is Dictionary else {}
+
+
+func _refresh_install_action() -> void:
+	var installed: String = INSTALLER_SCRIPT.installed_path(int(_detail.get("id", 0)))
+	if not installed.is_empty():
+		_install_button.text = "Installed"
+		_install_button.disabled = true
+		_install_status.text = "Installed in %s" % installed
+		_install_status.add_theme_color_override("font_color", SUCCESS)
+		return
+	var file: Dictionary = _selected_file()
+	if file.is_empty():
+		_install_button.text = "Install pack"
+		_install_button.disabled = true
+		_install_status.text = "This submission has no downloadable files."
+		return
+	var problem: String = INSTALLER_SCRIPT.installability_problem(file)
+	_install_button.text = "Install pack"
+	_install_button.disabled = not problem.is_empty() or Net.is_online()
+	if Net.is_online():
+		_install_status.text = "Leave the online lobby before installing packs so its pack list stays consistent."
+		_install_status.add_theme_color_override("font_color", WARNING)
+	elif not problem.is_empty():
+		_install_status.text = problem
+		_install_status.add_theme_color_override("font_color", DANGER)
+	else:
+		_install_status.text = "Ready to download, verify and install into packs_voice."
+		_install_status.add_theme_color_override("font_color", MUTED)
+
+
+func _on_install_pressed() -> void:
+	var file: Dictionary = _selected_file()
+	if file.is_empty() or _detail.is_empty() or Net.is_online(): return
+	_install_button.disabled = true
+	_file_picker.disabled = true
+	_install_progress.visible = true
+	_install_progress.min_value = 0
+	_install_progress.max_value = maxi(1, int(file.get("size", 0)))
+	_install_progress.value = 0
+	_installer.install(_detail, file)
+
+
+func _on_install_progress(received: int, total: int, status: String) -> void:
+	_install_progress.visible = true
+	_install_progress.max_value = maxi(1, total)
+	_install_progress.value = clampi(received, 0, maxi(1, total))
+	_install_status.text = status
+	_install_status.add_theme_color_override("font_color", MUTED)
+
+
+func _on_install_finished(result: Dictionary) -> void:
+	_install_progress.visible = false
+	_file_picker.disabled = false
+	_install_button.text = "Installed"
+	_install_button.disabled = true
+	var text: String = "Already installed" if bool(result.get("already_installed", false)) else "Installed"
+	_install_status.text = "%s in %s" % [text, str(result.get("path", "packs_voice"))]
+	if result.has("warning"): _install_status.text += "\n" + str(result["warning"])
+	_install_status.add_theme_color_override("font_color", SUCCESS)
+
+
+func _on_install_failed(message: String) -> void:
+	_install_progress.visible = false
+	_file_picker.disabled = false
+	_install_status.text = message
+	_install_status.add_theme_color_override("font_color", DANGER)
+	var file: Dictionary = _selected_file()
+	_install_button.text = "Retry install"
+	_install_button.disabled = (file.is_empty() or Net.is_online()
+		or not INSTALLER_SCRIPT.installability_problem(file).is_empty())
+
+
+func _on_request_failed(message: String) -> void:
+	_set_list_busy(false)
+	if _loading_detail:
+		_loading_detail = false
+		_detail_description.text = message
+		_install_status.text = "You can still open the submission on GameBanana."
+		_install_status.add_theme_color_override("font_color", DANGER)
+	else:
+		_list_status.text = message
+
+
+func _load_preview(url: String) -> void:
+	_image_http.cancel_request()
+	_preview_placeholder.visible = true
+	if not url.begins_with("https://images.gamebanana.com/"):
+		_preview_placeholder.text = "NO PREVIEW PROVIDED"
+		return
+	_preview_placeholder.text = "LOADING PREVIEW..."
+	var error: Error = _image_http.request(
+		url, ["User-Agent: TCV-Multiplayer/%s" % str(Net.MOD_VERSION)])
+	if error != OK: _preview_placeholder.text = "PREVIEW UNAVAILABLE"
+
+
+func _on_image_loaded(
+	result: int, response_code: int, _headers: PackedStringArray, body: PackedByteArray
+) -> void:
+	if result != HTTPRequest.RESULT_SUCCESS or response_code < 200 or response_code >= 300:
+		_preview_placeholder.text = "PREVIEW UNAVAILABLE"
+		return
+	var image: = Image.new()
+	var error: Error = image.load_webp_from_buffer(body)
+	if error != OK: error = image.load_jpg_from_buffer(body)
+	if error != OK: error = image.load_png_from_buffer(body)
+	if error == OK:
+		_preview.texture = ImageTexture.create_from_image(image)
+		_preview_placeholder.visible = false
+	else:
+		_preview_placeholder.text = "PREVIEW UNAVAILABLE"
+
+
+static func _button(text: String, primary: bool) -> Button:
+	var button: = Button.new()
+	button.text = text
+	button.custom_minimum_size.y = 38
+	button.add_theme_font_size_override("font_size", 14)
+	button.add_theme_color_override("font_color", Color("071019") if primary else TEXT)
+	button.add_theme_color_override("font_hover_color", Color("071019") if primary else TEXT)
+	button.add_theme_stylebox_override(
+		"normal", _box(ACCENT if primary else SURFACE_2, 7, ACCENT if primary else BORDER, 1))
+	button.add_theme_stylebox_override(
+		"hover", _box(ACCENT.lightened(0.15) if primary else Color("26324b"), 7, ACCENT, 1))
+	button.add_theme_stylebox_override(
+		"pressed", _box(ACCENT.darkened(0.1) if primary else Color("1d2941"), 7, ACCENT, 2))
+	return button
+
+
+static func _box(color: Color, radius: int, border: Color, width: int) -> StyleBoxFlat:
+	var box: = StyleBoxFlat.new()
+	box.bg_color = color
+	box.corner_radius_top_left = radius
+	box.corner_radius_top_right = radius
+	box.corner_radius_bottom_left = radius
+	box.corner_radius_bottom_right = radius
+	box.border_width_left = width
+	box.border_width_right = width
+	box.border_width_top = width
+	box.border_width_bottom = width
+	box.border_color = border
+	box.content_margin_left = 12
+	box.content_margin_right = 12
+	box.content_margin_top = 8
+	box.content_margin_bottom = 8
+	return box
+
+
+static func _format_bytes(bytes: int) -> String:
+	if bytes >= 1024 * 1024 * 1024: return "%.2f GB" % (float(bytes) / 1073741824.0)
+	if bytes >= 1024 * 1024: return "%.1f MB" % (float(bytes) / 1048576.0)
+	if bytes >= 1024: return "%.1f KB" % (float(bytes) / 1024.0)
+	return "%d bytes" % bytes

--- a/mod/net/community_pack_browser.gd
+++ b/mod/net/community_pack_browser.gd
@@ -19,7 +19,7 @@ const SUCCESS: Color = Color("63d69a")
 const DANGER: Color = Color("ff7b83")
 
 var _catalog: Node
-var _installer: Node
+var _downloads: Node
 var _image_http: HTTPRequest
 
 var _page: int = 1
@@ -48,7 +48,13 @@ var _file_picker: OptionButton
 var _install_status: Label
 var _install_progress: ProgressBar
 var _install_button: Button
+var _uninstall_button: Button
 var _open_button: Button
+var _downloads_button: Button
+var _downloads_modal: Control
+var _downloads_list: VBoxContainer
+var _download_summary: Label
+var _uninstall_dialog: ConfirmationDialog
 
 
 func _ready() -> void:
@@ -62,17 +68,15 @@ func _ready() -> void:
 	_catalog.detail_loaded.connect(_on_detail_loaded)
 	_catalog.request_failed.connect(_on_request_failed)
 	add_child(_catalog)
-	_installer = INSTALLER_SCRIPT.new()
-	_installer.progress.connect(_on_install_progress)
-	_installer.finished.connect(_on_install_finished)
-	_installer.failed.connect(_on_install_failed)
-	add_child(_installer)
+	_downloads = Net.community_pack_downloads
+	_downloads.changed.connect(_on_downloads_changed)
 	_image_http = HTTPRequest.new()
 	_image_http.use_threads = true
 	_image_http.timeout = 12.0
 	_image_http.body_size_limit = 12 * 1024 * 1024
 	_image_http.request_completed.connect(_on_image_loaded)
 	add_child(_image_http)
+	_on_downloads_changed()
 	_load_page()
 
 
@@ -83,13 +87,15 @@ func _fit_to_viewport() -> void:
 
 func _exit_tree() -> void:
 	if is_instance_valid(_catalog): _catalog.cancel()
-	if is_instance_valid(_installer) and _installer.is_busy(): _installer.cancel()
 	if is_instance_valid(_image_http): _image_http.cancel_request()
 
 
 func _unhandled_input(event: InputEvent) -> void:
-	if event.is_action_pressed("ui_cancel") and not _installer.is_busy():
-		get_viewport().set_input_as_handled()
+	if not event.is_action_pressed("ui_cancel"): return
+	get_viewport().set_input_as_handled()
+	if is_instance_valid(_downloads_modal) and _downloads_modal.visible:
+		_downloads_modal.visible = false
+	else:
 		closed.emit()
 
 
@@ -130,9 +136,12 @@ func _build_ui() -> void:
 	source.add_theme_font_size_override("font_size", 13)
 	source.add_theme_color_override("font_color", ACCENT)
 	header.add_child(source)
+	_downloads_button = _button("Downloads", false)
+	_downloads_button.pressed.connect(_show_downloads)
+	header.add_child(_downloads_button)
 	var close: Button = _button("Close", false)
-	close.pressed.connect(func() -> void:
-		if not _installer.is_busy(): closed.emit())
+	close.tooltip_text = "Downloads keep running after this screen closes."
+	close.pressed.connect(func() -> void: closed.emit())
 	header.add_child(close)
 
 	var tools: = HBoxContainer.new()
@@ -292,6 +301,10 @@ func _build_ui() -> void:
 	_install_button.disabled = true
 	_install_button.pressed.connect(_on_install_pressed)
 	detail_buttons.add_child(_install_button)
+	_uninstall_button = _button("Uninstall", false)
+	_uninstall_button.visible = false
+	_uninstall_button.pressed.connect(_on_uninstall_pressed)
+	detail_buttons.add_child(_uninstall_button)
 	_open_button = _button("Open on GameBanana", false)
 	_open_button.disabled = true
 	_open_button.pressed.connect(func() -> void:
@@ -304,6 +317,68 @@ func _build_ui() -> void:
 	caution.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
 	caution.add_theme_color_override("font_color", WARNING)
 	detail.add_child(caution)
+
+	_build_downloads_modal()
+
+
+func _build_downloads_modal() -> void:
+	_downloads_modal = Control.new()
+	_downloads_modal.set_anchors_and_offsets_preset(Control.PRESET_FULL_RECT)
+	_downloads_modal.mouse_filter = Control.MOUSE_FILTER_STOP
+	_downloads_modal.visible = false
+	add_child(_downloads_modal)
+	var backdrop: = ColorRect.new()
+	backdrop.color = Color(0.01, 0.015, 0.03, 0.88)
+	backdrop.set_anchors_and_offsets_preset(Control.PRESET_FULL_RECT)
+	_downloads_modal.add_child(backdrop)
+	var center: = CenterContainer.new()
+	center.set_anchors_and_offsets_preset(Control.PRESET_FULL_RECT)
+	_downloads_modal.add_child(center)
+	var panel: = PanelContainer.new()
+	panel.custom_minimum_size = Vector2(720, 430)
+	panel.add_theme_stylebox_override("panel", _box(SURFACE, 12, BORDER, 1))
+	center.add_child(panel)
+	var margin: = MarginContainer.new()
+	for side: String in ["left", "right", "top", "bottom"]:
+		margin.add_theme_constant_override("margin_" + side, 20)
+	panel.add_child(margin)
+	var column: = VBoxContainer.new()
+	column.add_theme_constant_override("separation", 12)
+	margin.add_child(column)
+	var header: = HBoxContainer.new()
+	column.add_child(header)
+	var title: = Label.new()
+	title.text = "DOWNLOAD QUEUE"
+	title.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	title.add_theme_font_size_override("font_size", 24)
+	title.add_theme_color_override("font_color", TEXT)
+	header.add_child(title)
+	var close: Button = _button("Close", false)
+	close.pressed.connect(func() -> void: _downloads_modal.visible = false)
+	header.add_child(close)
+	_download_summary = Label.new()
+	_download_summary.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
+	_download_summary.add_theme_color_override("font_color", MUTED)
+	column.add_child(_download_summary)
+	var scroll: = ScrollContainer.new()
+	scroll.size_flags_vertical = Control.SIZE_EXPAND_FILL
+	scroll.horizontal_scroll_mode = ScrollContainer.SCROLL_MODE_DISABLED
+	column.add_child(scroll)
+	_downloads_list = VBoxContainer.new()
+	_downloads_list.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	_downloads_list.add_theme_constant_override("separation", 8)
+	scroll.add_child(_downloads_list)
+	var note: = Label.new()
+	note.text = ("Downloads continue while this screen is closed and during offline play. "
+		+ "New queued downloads wait while you are in online multiplayer.")
+	note.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
+	note.add_theme_color_override("font_color", MUTED)
+	column.add_child(note)
+
+	_uninstall_dialog = ConfirmationDialog.new()
+	_uninstall_dialog.title = "Uninstall community pack?"
+	_uninstall_dialog.confirmed.connect(_confirm_uninstall)
+	add_child(_uninstall_dialog)
 
 
 func _load_page(force: bool = false) -> void:
@@ -386,7 +461,7 @@ func _render_list() -> void:
 
 
 func _select_record(record: Dictionary) -> void:
-	if _installer.is_busy() or _catalog.is_busy(): return
+	if _catalog.is_busy(): return
 	_loading_detail = true
 	_selected = record.duplicate(true)
 	_detail.clear()
@@ -445,73 +520,210 @@ func _selected_file() -> Dictionary:
 
 
 func _refresh_install_action() -> void:
-	var installed: String = INSTALLER_SCRIPT.installed_path(int(_detail.get("id", 0)))
+	if not is_instance_valid(_downloads): return
+	var mod_id: int = int(_detail.get("id", 0))
+	var installed: String = INSTALLER_SCRIPT.installed_path(mod_id)
+	_uninstall_button.visible = not installed.is_empty()
+	_uninstall_button.disabled = Net.is_online() or _mod_has_active_job(mod_id)
 	if not installed.is_empty():
 		_install_button.text = "Installed"
 		_install_button.disabled = true
+		_install_progress.visible = false
 		_install_status.text = "Installed in %s" % installed
+		if _mod_has_active_job(mod_id):
+			_install_status.text += "\nA download for this submission is still active."
 		_install_status.add_theme_color_override("font_color", SUCCESS)
 		return
 	var file: Dictionary = _selected_file()
 	if file.is_empty():
 		_install_button.text = "Install pack"
 		_install_button.disabled = true
+		_install_progress.visible = false
 		_install_status.text = "This submission has no downloadable files."
 		return
+	var job: Dictionary = _downloads.job_for(mod_id, int(file.get("id", 0)))
+	var state: String = str(job.get("state", ""))
+	if state in ["queued", "downloading", "verifying", "installing"]:
+		_install_button.text = "View downloads"
+		_install_button.disabled = false
+		_install_progress.visible = true
+		_install_progress.max_value = maxi(1, int(job.get("total", file.get("size", 0))))
+		_install_progress.value = clampi(
+			int(job.get("received", 0)), 0, int(_install_progress.max_value))
+		var status: String = str(job.get("status", "Queued"))
+		if state == "queued" and Net.is_online():
+			status = "Queued — waiting until you leave online multiplayer."
+		_install_status.text = status
+		_install_status.add_theme_color_override("font_color", MUTED)
+		return
+	if state in ["failed", "canceled"]:
+		_install_progress.visible = false
+		_install_button.text = "Retry download"
+		_install_button.disabled = false
+		_install_status.text = str(job.get(
+			"error", "Canceled" if state == "canceled" else "Download failed"))
+		if _install_status.text.is_empty(): _install_status.text = "Canceled"
+		_install_status.add_theme_color_override("font_color", DANGER if state == "failed" else MUTED)
+		return
 	var problem: String = INSTALLER_SCRIPT.installability_problem(file)
-	_install_button.text = "Install pack"
-	_install_button.disabled = not problem.is_empty() or Net.is_online()
+	_install_progress.visible = false
+	_install_button.text = "Add to download queue"
+	_install_button.disabled = not problem.is_empty()
 	if Net.is_online():
-		_install_status.text = "Leave the online lobby before installing packs so its pack list stays consistent."
+		_install_status.text = "This will wait in the queue until you leave online multiplayer."
 		_install_status.add_theme_color_override("font_color", WARNING)
 	elif not problem.is_empty():
 		_install_status.text = problem
 		_install_status.add_theme_color_override("font_color", DANGER)
 	else:
-		_install_status.text = "Ready to download, verify and install into packs_voice."
+		_install_status.text = "Ready to queue. Downloads continue during offline play."
 		_install_status.add_theme_color_override("font_color", MUTED)
 
 
 func _on_install_pressed() -> void:
 	var file: Dictionary = _selected_file()
-	if file.is_empty() or _detail.is_empty() or Net.is_online(): return
-	_install_button.disabled = true
-	_file_picker.disabled = true
-	_install_progress.visible = true
-	_install_progress.min_value = 0
-	_install_progress.max_value = maxi(1, int(file.get("size", 0)))
-	_install_progress.value = 0
-	_installer.install(_detail, file)
+	if file.is_empty() or _detail.is_empty(): return
+	var existing: Dictionary = _downloads.job_for(
+		int(_detail.get("id", 0)), int(file.get("id", 0)))
+	if str(existing.get("state", "")) in ["queued", "downloading", "verifying", "installing"]:
+		_show_downloads()
+		return
+	_downloads.enqueue(_detail, file)
+	_refresh_install_action()
 
 
-func _on_install_progress(received: int, total: int, status: String) -> void:
-	_install_progress.visible = true
-	_install_progress.max_value = maxi(1, total)
-	_install_progress.value = clampi(received, 0, maxi(1, total))
-	_install_status.text = status
-	_install_status.add_theme_color_override("font_color", MUTED)
+func _on_downloads_changed() -> void:
+	if not is_instance_valid(_downloads_button): return
+	var active: int = _downloads.active_count()
+	_downloads_button.text = "Downloads (%d)" % active if active > 0 else "Downloads"
+	if is_instance_valid(_downloads_modal) and _downloads_modal.visible: _render_downloads()
+	if not _update_selected_active_download(): _refresh_install_action()
 
 
-func _on_install_finished(result: Dictionary) -> void:
-	_install_progress.visible = false
-	_file_picker.disabled = false
-	_install_button.text = "Installed"
-	_install_button.disabled = true
-	var text: String = "Already installed" if bool(result.get("already_installed", false)) else "Installed"
-	_install_status.text = "%s in %s" % [text, str(result.get("path", "packs_voice"))]
-	if result.has("warning"): _install_status.text += "\n" + str(result["warning"])
-	_install_status.add_theme_color_override("font_color", SUCCESS)
-
-
-func _on_install_failed(message: String) -> void:
-	_install_progress.visible = false
-	_file_picker.disabled = false
-	_install_status.text = message
-	_install_status.add_theme_color_override("font_color", DANGER)
+func _update_selected_active_download() -> bool:
 	var file: Dictionary = _selected_file()
-	_install_button.text = "Retry install"
-	_install_button.disabled = (file.is_empty() or Net.is_online()
-		or not INSTALLER_SCRIPT.installability_problem(file).is_empty())
+	if file.is_empty() or _detail.is_empty(): return false
+	var job: Dictionary = _downloads.job_for(
+		int(_detail.get("id", 0)), int(file.get("id", 0)))
+	var state: String = str(job.get("state", ""))
+	if state not in ["queued", "downloading", "verifying", "installing"]: return false
+	_install_button.text = "View downloads"
+	_install_button.disabled = false
+	_install_progress.visible = true
+	_install_progress.max_value = maxi(1, int(job.get("total", file.get("size", 0))))
+	_install_progress.value = clampi(int(job.get("received", 0)), 0, int(_install_progress.max_value))
+	_install_status.text = str(job.get("status", "Queued"))
+	if state == "queued" and Net.is_online():
+		_install_status.text = "Queued — waiting until you leave online multiplayer."
+	_install_status.add_theme_color_override("font_color", MUTED)
+	return true
+
+
+func _show_downloads() -> void:
+	_render_downloads()
+	_downloads_modal.visible = true
+
+
+func _render_downloads() -> void:
+	if not is_instance_valid(_downloads_list) or not is_instance_valid(_downloads): return
+	for child: Node in _downloads_list.get_children():
+		_downloads_list.remove_child(child)
+		child.queue_free()
+	var jobs: Array[Dictionary] = _downloads.get_jobs()
+	var active: int = _downloads.active_count()
+	_download_summary.text = (
+		"%d active or queued. Downloads run one at a time to avoid saturating the connection." % active)
+	if jobs.is_empty():
+		var empty: = Label.new()
+		empty.text = "No downloads in this session."
+		empty.add_theme_color_override("font_color", MUTED)
+		_downloads_list.add_child(empty)
+		return
+	for job: Dictionary in jobs:
+		var card: = PanelContainer.new()
+		card.add_theme_stylebox_override("panel", _box(SURFACE_2, 8, BORDER, 1))
+		_downloads_list.add_child(card)
+		var row: = HBoxContainer.new()
+		row.add_theme_constant_override("separation", 12)
+		card.add_child(row)
+		var info: = VBoxContainer.new()
+		info.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+		row.add_child(info)
+		var mod: Dictionary = job.get("mod", {})
+		var file: Dictionary = job.get("file", {})
+		var title: = Label.new()
+		title.text = "%s  —  %s" % [str(mod.get("name", "Dub pack")), str(file.get("name", "ZIP"))]
+		title.text_overrun_behavior = TextServer.OVERRUN_TRIM_ELLIPSIS
+		title.add_theme_color_override("font_color", TEXT)
+		info.add_child(title)
+		var state: String = str(job.get("state", "queued"))
+		var status: = Label.new()
+		status.text = str(job.get("status", state.capitalize()))
+		if state == "queued" and Net.is_online():
+			status.text = "Queued — waiting until online multiplayer closes"
+		if state == "failed" and not str(job.get("error", "")).is_empty():
+			status.text += " — " + str(job["error"])
+		status.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
+		status.add_theme_color_override(
+			"font_color", DANGER if state == "failed" else SUCCESS if state == "finished" else MUTED)
+		info.add_child(status)
+		if state in ["queued", "downloading", "verifying", "installing"]:
+			var progress: = ProgressBar.new()
+			progress.show_percentage = state != "queued"
+			progress.max_value = maxi(1, int(job.get("total", 0)))
+			progress.value = clampi(int(job.get("received", 0)), 0, int(progress.max_value))
+			info.add_child(progress)
+		var actions: = VBoxContainer.new()
+		row.add_child(actions)
+		var id: String = str(job.get("id", ""))
+		if state in ["queued", "downloading"]:
+			var cancel: Button = _button("Cancel", false)
+			cancel.pressed.connect(_downloads.cancel.bind(id))
+			actions.add_child(cancel)
+		elif state in ["failed", "canceled"]:
+			var retry: Button = _button("Retry", true)
+			retry.pressed.connect(_downloads.retry.bind(id))
+			actions.add_child(retry)
+			var dismiss: Button = _button("Dismiss", false)
+			dismiss.pressed.connect(_downloads.dismiss.bind(id))
+			actions.add_child(dismiss)
+		elif state == "finished":
+			var dismiss: Button = _button("Dismiss", false)
+			dismiss.pressed.connect(_downloads.dismiss.bind(id))
+			actions.add_child(dismiss)
+
+
+func _mod_has_active_job(mod_id: int) -> bool:
+	if mod_id <= 0: return false
+	for job: Dictionary in _downloads.get_jobs():
+		var mod: Dictionary = job.get("mod", {})
+		if (int(mod.get("id", 0)) == mod_id
+			and str(job.get("state", "")) in ["queued", "downloading", "verifying", "installing"]):
+			return true
+	return false
+
+
+func _on_uninstall_pressed() -> void:
+	var mod_id: int = int(_detail.get("id", 0))
+	if mod_id <= 0 or Net.is_online() or _mod_has_active_job(mod_id): return
+	_uninstall_dialog.dialog_text = ("Remove '%s' and all files this installer placed in its pack folder?\n\n"
+		+ "Manually installed packs are never removed by this button.") % str(_detail.get("name", "Dub pack"))
+	_uninstall_dialog.popup_centered(Vector2i(560, 190))
+
+
+func _confirm_uninstall() -> void:
+	var mod_id: int = int(_detail.get("id", 0))
+	if mod_id <= 0 or Net.is_online() or _mod_has_active_job(mod_id): return
+	var result: Dictionary = INSTALLER_SCRIPT.uninstall(mod_id)
+	if result.has("error"):
+		_install_status.text = str(result["error"])
+		_install_status.add_theme_color_override("font_color", DANGER)
+		return
+	_downloads.dismiss_for_mod(mod_id)
+	Net.community_pack_library_changed()
+	_refresh_install_action()
+	_install_status.text = "Uninstalled %s." % str(_detail.get("name", "community pack"))
+	_install_status.add_theme_color_override("font_color", SUCCESS)
 
 
 func _on_request_failed(message: String) -> void:

--- a/mod/net/community_pack_browser.gd
+++ b/mod/net/community_pack_browser.gd
@@ -50,13 +50,19 @@ var _install_progress: ProgressBar
 var _install_button: Button
 var _uninstall_button: Button
 var _open_button: Button
+var _installed_button: Button
 var _downloads_button: Button
 var _downloads_modal: Control
 var _downloads_list: VBoxContainer
 var _download_summary: Label
 var _online_downloads_box: CheckBox
 var _downloads_note: Label
+var _installed_modal: Control
+var _installed_list: VBoxContainer
+var _installed_summary: Label
+var _installed_feedback: Label
 var _uninstall_dialog: ConfirmationDialog
+var _pending_uninstall: Dictionary = {}
 
 
 func _ready() -> void:
@@ -95,7 +101,9 @@ func _exit_tree() -> void:
 func _unhandled_input(event: InputEvent) -> void:
 	if not event.is_action_pressed("ui_cancel"): return
 	get_viewport().set_input_as_handled()
-	if is_instance_valid(_downloads_modal) and _downloads_modal.visible:
+	if is_instance_valid(_installed_modal) and _installed_modal.visible:
+		_installed_modal.visible = false
+	elif is_instance_valid(_downloads_modal) and _downloads_modal.visible:
 		_downloads_modal.visible = false
 	else:
 		closed.emit()
@@ -138,6 +146,10 @@ func _build_ui() -> void:
 	source.add_theme_font_size_override("font_size", 13)
 	source.add_theme_color_override("font_color", ACCENT)
 	header.add_child(source)
+	_installed_button = _button("Installed", false)
+	_installed_button.tooltip_text = "View and uninstall community packs installed by this mod."
+	_installed_button.pressed.connect(_show_installed)
+	header.add_child(_installed_button)
 	_downloads_button = _button("Downloads", false)
 	_downloads_button.pressed.connect(_show_downloads)
 	header.add_child(_downloads_button)
@@ -321,6 +333,7 @@ func _build_ui() -> void:
 	detail.add_child(caution)
 
 	_build_downloads_modal()
+	_build_installed_modal()
 
 
 func _build_downloads_modal() -> void:
@@ -388,6 +401,69 @@ func _build_downloads_modal() -> void:
 	_uninstall_dialog.title = "Uninstall community pack?"
 	_uninstall_dialog.confirmed.connect(_confirm_uninstall)
 	add_child(_uninstall_dialog)
+
+
+func _build_installed_modal() -> void:
+	_installed_modal = Control.new()
+	_installed_modal.set_anchors_and_offsets_preset(Control.PRESET_FULL_RECT)
+	_installed_modal.mouse_filter = Control.MOUSE_FILTER_STOP
+	_installed_modal.visible = false
+	add_child(_installed_modal)
+	var backdrop: = ColorRect.new()
+	backdrop.color = Color(0.01, 0.015, 0.03, 0.88)
+	backdrop.set_anchors_and_offsets_preset(Control.PRESET_FULL_RECT)
+	_installed_modal.add_child(backdrop)
+	var center: = CenterContainer.new()
+	center.set_anchors_and_offsets_preset(Control.PRESET_FULL_RECT)
+	_installed_modal.add_child(center)
+	var panel: = PanelContainer.new()
+	panel.custom_minimum_size = Vector2(720, 470)
+	panel.add_theme_stylebox_override("panel", _box(SURFACE, 12, BORDER, 1))
+	center.add_child(panel)
+	var margin: = MarginContainer.new()
+	for side: String in ["left", "right", "top", "bottom"]:
+		margin.add_theme_constant_override("margin_" + side, 20)
+	panel.add_child(margin)
+	var column: = VBoxContainer.new()
+	column.add_theme_constant_override("separation", 12)
+	margin.add_child(column)
+	var header: = HBoxContainer.new()
+	header.add_theme_constant_override("separation", 8)
+	column.add_child(header)
+	var title: = Label.new()
+	title.text = "INSTALLED COMMUNITY PACKS"
+	title.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	title.add_theme_font_size_override("font_size", 24)
+	title.add_theme_color_override("font_color", TEXT)
+	header.add_child(title)
+	var refresh: Button = _button("Refresh", false)
+	refresh.pressed.connect(_render_installed)
+	header.add_child(refresh)
+	var close: Button = _button("Close", false)
+	close.pressed.connect(func() -> void: _installed_modal.visible = false)
+	header.add_child(close)
+	_installed_summary = Label.new()
+	_installed_summary.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
+	_installed_summary.add_theme_color_override("font_color", MUTED)
+	column.add_child(_installed_summary)
+	var scroll: = ScrollContainer.new()
+	scroll.size_flags_vertical = Control.SIZE_EXPAND_FILL
+	scroll.horizontal_scroll_mode = ScrollContainer.SCROLL_MODE_DISABLED
+	column.add_child(scroll)
+	_installed_list = VBoxContainer.new()
+	_installed_list.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	_installed_list.add_theme_constant_override("separation", 8)
+	scroll.add_child(_installed_list)
+	_installed_feedback = Label.new()
+	_installed_feedback.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
+	_installed_feedback.add_theme_color_override("font_color", MUTED)
+	column.add_child(_installed_feedback)
+	var note: = Label.new()
+	note.text = ("Only packs installed by this browser are listed. Manually installed folders are "
+		+ "never removed, and uninstalling is disabled during online play.")
+	note.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
+	note.add_theme_color_override("font_color", MUTED)
+	column.add_child(note)
 
 
 func _load_page(force: bool = false) -> void:
@@ -634,8 +710,84 @@ func _update_selected_active_download() -> bool:
 
 
 func _show_downloads() -> void:
+	if is_instance_valid(_installed_modal): _installed_modal.visible = false
 	_render_downloads()
 	_downloads_modal.visible = true
+
+
+func _show_installed() -> void:
+	if is_instance_valid(_downloads_modal): _downloads_modal.visible = false
+	_installed_feedback.text = ""
+	_render_installed()
+	_installed_modal.visible = true
+
+
+func _render_installed() -> void:
+	if not is_instance_valid(_installed_list): return
+	for child: Node in _installed_list.get_children():
+		_installed_list.remove_child(child)
+		child.queue_free()
+	var packs: Array[Dictionary] = INSTALLER_SCRIPT.installed_packs()
+	_installed_summary.text = (
+		"%d community pack%s installed by this browser." % [
+			packs.size(), "" if packs.size() == 1 else "s"])
+	if packs.is_empty():
+		var empty: = Label.new()
+		empty.text = "No browser-installed community packs were found."
+		empty.add_theme_color_override("font_color", MUTED)
+		_installed_list.add_child(empty)
+		return
+	for pack: Dictionary in packs:
+		var card: = PanelContainer.new()
+		card.add_theme_stylebox_override("panel", _box(SURFACE_2, 8, BORDER, 1))
+		_installed_list.add_child(card)
+		var row: = HBoxContainer.new()
+		row.add_theme_constant_override("separation", 12)
+		card.add_child(row)
+		var info: = VBoxContainer.new()
+		info.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+		row.add_child(info)
+		var title: = Label.new()
+		title.text = str(pack.get("name", pack.get("folder", "Dub pack")))
+		title.text_overrun_behavior = TextServer.OVERRUN_TRIM_ELLIPSIS
+		title.add_theme_color_override("font_color", TEXT)
+		info.add_child(title)
+		var details: PackedStringArray = []
+		var author: String = str(pack.get("author", "")).strip_edges()
+		if not author.is_empty(): details.append("by " + author)
+		var installed_bytes: int = int(pack.get("installed_bytes", 0))
+		if installed_bytes > 0: details.append(_format_bytes(installed_bytes))
+		var installed_unix: int = int(pack.get("installed_unix", 0))
+		if installed_unix > 0:
+			details.append("installed " + Time.get_datetime_string_from_unix_time(
+				installed_unix, true))
+		var meta: = Label.new()
+		meta.text = "  •  ".join(details)
+		meta.add_theme_color_override("font_color", MUTED)
+		info.add_child(meta)
+		var folder: = Label.new()
+		folder.text = "Folder: %s" % str(pack.get("folder", ""))
+		folder.text_overrun_behavior = TextServer.OVERRUN_TRIM_ELLIPSIS
+		folder.add_theme_font_size_override("font_size", 12)
+		folder.add_theme_color_override("font_color", MUTED.darkened(0.12))
+		info.add_child(folder)
+		var actions: = VBoxContainer.new()
+		actions.add_theme_constant_override("separation", 6)
+		row.add_child(actions)
+		var mod_id: int = int(pack.get("mod_id", 0))
+		var uninstall: Button = _button("Uninstall", false)
+		uninstall.disabled = Net.is_online() or _mod_has_active_job(mod_id)
+		if Net.is_online():
+			uninstall.tooltip_text = "Leave online play before changing the pack library."
+		elif _mod_has_active_job(mod_id):
+			uninstall.tooltip_text = "Cancel or finish this pack's active download first."
+		uninstall.pressed.connect(_request_uninstall.bind(pack))
+		actions.add_child(uninstall)
+		var profile_url: String = str(pack.get("profile_url", ""))
+		if profile_url.begins_with("https://gamebanana.com/"):
+			var page: Button = _button("GameBanana", false)
+			page.pressed.connect(_open_gamebanana.bind(profile_url))
+			actions.add_child(page)
 
 
 func _render_downloads() -> void:
@@ -723,27 +875,55 @@ func _mod_has_active_job(mod_id: int) -> bool:
 	return false
 
 
+func _open_gamebanana(url: String) -> void:
+	if url.begins_with("https://gamebanana.com/"): OS.shell_open(url)
+
+
 func _on_uninstall_pressed() -> void:
 	var mod_id: int = int(_detail.get("id", 0))
 	if mod_id <= 0 or Net.is_online() or _mod_has_active_job(mod_id): return
+	_request_uninstall({
+		"mod_id": mod_id,
+		"name": str(_detail.get("name", "Dub pack")),
+		"path": INSTALLER_SCRIPT.installed_path(mod_id),
+	})
+
+
+func _request_uninstall(pack: Dictionary) -> void:
+	var mod_id: int = int(pack.get("mod_id", 0))
+	if mod_id <= 0 or Net.is_online() or _mod_has_active_job(mod_id): return
+	_pending_uninstall = pack.duplicate(true)
 	_uninstall_dialog.dialog_text = ("Remove '%s' and all files this installer placed in its pack folder?\n\n"
-		+ "Manually installed packs are never removed by this button.") % str(_detail.get("name", "Dub pack"))
+		+ "Manually installed packs are never removed by this button.") % str(
+			pack.get("name", "Dub pack"))
 	_uninstall_dialog.popup_centered(Vector2i(560, 190))
 
 
 func _confirm_uninstall() -> void:
-	var mod_id: int = int(_detail.get("id", 0))
+	var pack: Dictionary = _pending_uninstall.duplicate(true)
+	_pending_uninstall.clear()
+	var mod_id: int = int(pack.get("mod_id", 0))
 	if mod_id <= 0 or Net.is_online() or _mod_has_active_job(mod_id): return
-	var result: Dictionary = INSTALLER_SCRIPT.uninstall(mod_id)
+	var result: Dictionary = INSTALLER_SCRIPT.uninstall(mod_id, str(pack.get("path", "")))
 	if result.has("error"):
-		_install_status.text = str(result["error"])
-		_install_status.add_theme_color_override("font_color", DANGER)
+		var message: String = str(result["error"])
+		if is_instance_valid(_installed_feedback):
+			_installed_feedback.text = message
+			_installed_feedback.add_theme_color_override("font_color", DANGER)
+		if int(_detail.get("id", 0)) == mod_id:
+			_install_status.text = message
+			_install_status.add_theme_color_override("font_color", DANGER)
 		return
 	_downloads.dismiss_for_mod(mod_id)
 	Net.community_pack_library_changed()
-	_refresh_install_action()
-	_install_status.text = "Uninstalled %s." % str(_detail.get("name", "community pack"))
-	_install_status.add_theme_color_override("font_color", SUCCESS)
+	if int(_detail.get("id", 0)) == mod_id:
+		_refresh_install_action()
+		_install_status.text = "Uninstalled %s." % str(pack.get("name", "community pack"))
+		_install_status.add_theme_color_override("font_color", SUCCESS)
+	if is_instance_valid(_installed_list):
+		_render_installed()
+		_installed_feedback.text = "Uninstalled %s." % str(pack.get("name", "community pack"))
+		_installed_feedback.add_theme_color_override("font_color", SUCCESS)
 
 
 func _on_request_failed(message: String) -> void:

--- a/mod/net/community_pack_browser.gd
+++ b/mod/net/community_pack_browser.gd
@@ -297,6 +297,12 @@ func _build_ui() -> void:
 	file_label.add_theme_color_override("font_color", MUTED)
 	detail.add_child(file_label)
 	_file_picker = OptionButton.new()
+	# GameBanana filenames are untrusted layout input too. OptionButton normally
+	# makes its minimum width equal to its longest item, so one essay-length name
+	# can push the entire split view beyond the viewport.
+	_file_picker.fit_to_longest_item = false
+	_file_picker.text_overrun_behavior = TextServer.OVERRUN_TRIM_ELLIPSIS
+	_file_picker.size_flags_horizontal = Control.SIZE_EXPAND_FILL
 	_file_picker.disabled = true
 	_file_picker.item_selected.connect(func(_index: int) -> void: _refresh_install_action())
 	detail.add_child(_file_picker)
@@ -517,13 +523,21 @@ func _render_list() -> void:
 		var row: Button = Button.new()
 		row.alignment = HORIZONTAL_ALIGNMENT_LEFT
 		row.custom_minimum_size.y = 68
+		row.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+		row.clip_text = true
 		row.text_overrun_behavior = TextServer.OVERRUN_TRIM_ELLIPSIS
 		var category: String = str(record.get("subcategory", ""))
 		if category.is_empty(): category = str(record.get("category", "Dub Mode"))
 		if category.is_empty(): category = "Dub Mode"
 		var warning: String = "  •  CONTENT-RATED" if bool(record.get("content_rated", false)) else ""
-		row.text = "%s\nby %s  •  %s%s" % [record["name"], record["author"], category, warning]
-		row.tooltip_text = str(record.get("name", ""))
+		row.text = "%s\nby %s  •  %s%s" % [
+			_compact_text(str(record["name"]), 64),
+			_compact_text(str(record["author"]), 36),
+			_compact_text(category, 28),
+			warning,
+		]
+		row.tooltip_text = "%s\nby %s" % [
+			str(record.get("name", "")), str(record.get("author", "Unknown creator"))]
 		row.add_theme_font_size_override("font_size", 15)
 		row.add_theme_color_override("font_color", TEXT)
 		row.add_theme_color_override("font_hover_color", TEXT)
@@ -584,8 +598,12 @@ func _on_detail_loaded(detail: Dictionary) -> void:
 	for file_value: Variant in Array(detail.get("files", [])):
 		if not file_value is Dictionary: continue
 		var file: Dictionary = file_value
-		_file_picker.add_item("%s  —  %s" % [file["name"], _format_bytes(int(file["size"]))])
-		_file_picker.set_item_metadata(_file_picker.item_count - 1, file)
+		var full_name: String = str(file["name"])
+		_file_picker.add_item("%s  —  %s" % [
+			_compact_text(full_name, 62), _format_bytes(int(file["size"]))])
+		var item_index: int = _file_picker.item_count - 1
+		_file_picker.set_item_metadata(item_index, file)
+		_file_picker.get_popup().set_item_tooltip(item_index, full_name)
 	_file_picker.disabled = _file_picker.item_count == 0
 	if _file_picker.item_count > 0:
 		var first_zip: int = 0
@@ -749,6 +767,8 @@ func _render_installed() -> void:
 		row.add_child(info)
 		var title: = Label.new()
 		title.text = str(pack.get("name", pack.get("folder", "Dub pack")))
+		title.clip_text = true
+		title.size_flags_horizontal = Control.SIZE_EXPAND_FILL
 		title.text_overrun_behavior = TextServer.OVERRUN_TRIM_ELLIPSIS
 		title.add_theme_color_override("font_color", TEXT)
 		info.add_child(title)
@@ -767,6 +787,8 @@ func _render_installed() -> void:
 		info.add_child(meta)
 		var folder: = Label.new()
 		folder.text = "Folder: %s" % str(pack.get("folder", ""))
+		folder.clip_text = true
+		folder.size_flags_horizontal = Control.SIZE_EXPAND_FILL
 		folder.text_overrun_behavior = TextServer.OVERRUN_TRIM_ELLIPSIS
 		folder.add_theme_font_size_override("font_size", 12)
 		folder.add_theme_color_override("font_color", MUTED.darkened(0.12))
@@ -825,7 +847,11 @@ func _render_downloads() -> void:
 		var file: Dictionary = job.get("file", {})
 		var title: = Label.new()
 		title.text = "%s  —  %s" % [str(mod.get("name", "Dub pack")), str(file.get("name", "ZIP"))]
+		title.clip_text = true
+		title.size_flags_horizontal = Control.SIZE_EXPAND_FILL
 		title.text_overrun_behavior = TextServer.OVERRUN_TRIM_ELLIPSIS
+		title.tooltip_text = "%s — %s" % [
+			str(mod.get("name", "Dub pack")), str(file.get("name", "ZIP"))]
 		title.add_theme_color_override("font_color", TEXT)
 		info.add_child(title)
 		var state: String = str(job.get("state", "queued"))
@@ -1006,3 +1032,12 @@ static func _format_bytes(bytes: int) -> String:
 	if bytes >= 1024 * 1024: return "%.1f MB" % (float(bytes) / 1048576.0)
 	if bytes >= 1024: return "%.1f KB" % (float(bytes) / 1024.0)
 	return "%d bytes" % bytes
+
+
+static func _compact_text(value: String, limit: int) -> String:
+	if value.length() <= limit: return value
+	if limit < 8: return value.left(maxi(1, limit - 1)) + "…"
+	# Keep the tail because archive extensions and numbered variants tend to live
+	# there, while still putting most of the useful title at the front.
+	var tail: int = mini(14, limit / 4)
+	return value.left(limit - tail - 1) + "…" + value.right(tail)

--- a/mod/net/community_pack_installer.gd
+++ b/mod/net/community_pack_installer.gd
@@ -296,6 +296,8 @@ static func _validate_and_extract(
 		"profile_url": str(mod.get("profile_url", "")),
 		"archive_name": str(file.get("name", "")),
 		"archive_md5": str(file.get("md5", "")),
+		"installed_files": chosen.size(),
+		"installed_bytes": total,
 		"installed_unix": int(Time.get_unix_time_from_system()),
 	}
 	var manifest_file: FileAccess = FileAccess.open(staging.path_join(MANIFEST_NAME), FileAccess.WRITE)
@@ -459,8 +461,36 @@ static func installed_path(mod_id: int) -> String:
 	return ""
 
 
-static func uninstall(mod_id: int) -> Dictionary:
-	var path: String = installed_path(mod_id).replace("\\", "/").trim_suffix("/")
+static func installed_packs(voice_root_override: String = "") -> Array[Dictionary]:
+	var voice_root: String = (
+		str(FileManager.MODPACKS_VOICE) if voice_root_override.is_empty()
+		else voice_root_override).replace("\\", "/").trim_suffix("/")
+	var packs: Array[Dictionary] = []
+	var parent: DirAccess = DirAccess.open(voice_root)
+	if parent == null: return packs
+	parent.include_hidden = true
+	for folder: String in parent.get_directories():
+		if parent.is_link(folder): continue
+		var path: String = voice_root.path_join(folder)
+		var manifest_path: String = path.path_join(MANIFEST_NAME)
+		if not FileAccess.file_exists(manifest_path): continue
+		var parsed: Variant = JSON.parse_string(FileAccess.get_file_as_string(manifest_path))
+		if (not parsed is Dictionary or str(parsed.get("provider", "")) != "gamebanana"
+			or int(parsed.get("mod_id", 0)) <= 0):
+			continue
+		var record: Dictionary = parsed.duplicate(true)
+		record["path"] = path
+		record["folder"] = folder
+		packs.append(record)
+	packs.sort_custom(func(a: Dictionary, b: Dictionary) -> bool:
+		return str(a.get("name", "")).naturalnocasecmp_to(str(b.get("name", ""))) < 0)
+	return packs
+
+
+static func uninstall(mod_id: int, exact_path: String = "") -> Dictionary:
+	var path: String = (
+		exact_path if not exact_path.is_empty()
+		else installed_path(mod_id)).replace("\\", "/").trim_suffix("/")
 	if path.is_empty(): return {"error": "This community pack is not installed."}
 	var voice_root: String = str(FileManager.MODPACKS_VOICE).replace("\\", "/").trim_suffix("/")
 	return _uninstall_path(mod_id, path, voice_root, true)

--- a/mod/net/community_pack_installer.gd
+++ b/mod/net/community_pack_installer.gd
@@ -10,6 +10,7 @@ signal failed(message: String)
 const DOWNLOAD_ROOT: String = "user://community_pack_downloads"
 const REGISTRY_PATH: String = "user://community_pack_registry.json"
 const MANIFEST_NAME: String = ".tcv-community-pack.json"
+const NO_DUB_ROOT: String = "::missing-dub-root::"
 
 const MAX_ARCHIVE_BYTES: int = 1024 * 1024 * 1024
 const MAX_EXPANDED_BYTES: int = 4 * 1024 * 1024 * 1024
@@ -190,7 +191,7 @@ static func _validate_and_extract(
 	for value: Variant in Array(indexed.get("entries", [])):
 		if value is Dictionary: entries.append(value)
 	var root: String = _find_dub_root(entries)
-	if root == String.chr(0):
+	if root == NO_DUB_ROOT:
 		return {"error": "No dub pack was found in the archive. A dub pack needs an OGV video and audio clips."}
 
 	var chosen: Array[Dictionary] = []
@@ -411,7 +412,7 @@ static func inspect_zip(path: String) -> Dictionary:
 
 
 static func _find_dub_root(entries: Array[Dictionary]) -> String:
-	var best: String = String.chr(0)
+	var best: String = NO_DUB_ROOT
 	var best_audio: int = -1
 	for entry: Dictionary in entries:
 		if bool(entry.get("directory", false)): continue
@@ -428,7 +429,7 @@ static func _find_dub_root(entries: Array[Dictionary]) -> String:
 		if audio > best_audio or (audio == best_audio and candidate.length() > best.length()):
 			best = candidate
 			best_audio = audio
-	return best if best_audio > 0 else String.chr(0)
+	return best if best_audio > 0 else NO_DUB_ROOT
 
 
 static func installed_path(mod_id: int) -> String:

--- a/mod/net/community_pack_installer.gd
+++ b/mod/net/community_pack_installer.gd
@@ -93,8 +93,12 @@ func install(mod: Dictionary, file: Dictionary) -> void:
 
 static func installability_problem(file: Dictionary) -> String:
 	var name: String = str(file.get("name", ""))
-	if name.get_extension().to_lower() != "zip":
-		return "This file is not a ZIP. RAR and 7z support is not available yet."
+	var extension: String = name.get_extension().to_lower()
+	if extension == "rar":
+		return ("This is a RAR archive. Safe RAR extraction is not bundled yet; "
+			+ "choose a ZIP file from this submission if one is available.")
+	if extension != "zip":
+		return "This file is not a ZIP. Only ZIP archives are supported right now."
 	var size: int = int(file.get("size", 0))
 	if size <= 0: return "GameBanana did not report a valid file size."
 	if size > MAX_ARCHIVE_BYTES: return "This archive is larger than the 1 GB safety limit."

--- a/mod/net/community_pack_installer.gd
+++ b/mod/net/community_pack_installer.gd
@@ -459,6 +459,42 @@ static func installed_path(mod_id: int) -> String:
 	return ""
 
 
+static func uninstall(mod_id: int) -> Dictionary:
+	var path: String = installed_path(mod_id).replace("\\", "/").trim_suffix("/")
+	if path.is_empty(): return {"error": "This community pack is not installed."}
+	var voice_root: String = str(FileManager.MODPACKS_VOICE).replace("\\", "/").trim_suffix("/")
+	return _uninstall_path(mod_id, path, voice_root, true)
+
+
+static func _uninstall_path(
+	mod_id: int, installed: String, voice_root_value: String, update_registry: bool
+) -> Dictionary:
+	var path: String = installed.replace("\\", "/").trim_suffix("/")
+	var voice_root: String = voice_root_value.replace("\\", "/").trim_suffix("/")
+	# Only a direct child created by this installer can be removed. Never turn a
+	# registry entry or edited manifest into a recursive delete outside the pack
+	# library.
+	if path.get_base_dir() != voice_root:
+		return {"error": "The installed pack is outside packs_voice and was not removed."}
+	var parent: DirAccess = DirAccess.open(voice_root)
+	if parent == null or parent.is_link(path.get_file()):
+		return {"error": "The installed pack folder is not safe to remove automatically."}
+	var manifest_path: String = path.path_join(MANIFEST_NAME)
+	if not FileAccess.file_exists(manifest_path):
+		return {"error": "This folder has no community-pack manifest, so it was not removed."}
+	var parsed: Variant = JSON.parse_string(FileAccess.get_file_as_string(manifest_path))
+	if (not parsed is Dictionary or str(parsed.get("provider", "")) != "gamebanana"
+		or int(parsed.get("mod_id", 0)) != mod_id):
+		return {"error": "The community-pack manifest did not match; nothing was removed."}
+	if not _remove_installed_tree(path, path):
+		return {"error": "Could not completely remove the installed pack."}
+	if update_registry:
+		var registry: Dictionary = load_registry()
+		registry.erase(str(mod_id))
+		save_registry(registry)
+	return {"path": path}
+
+
 static func load_registry() -> Dictionary:
 	if not FileAccess.file_exists(REGISTRY_PATH): return {}
 	var parsed: Variant = JSON.parse_string(FileAccess.get_file_as_string(REGISTRY_PATH))
@@ -507,9 +543,27 @@ static func _remove_tree(path: String, staging_root: String) -> void:
 	if not path.begins_with(staging_root + "/") or not DirAccess.dir_exists_absolute(path): return
 	var dir: DirAccess = DirAccess.open(path)
 	if dir == null: return
+	dir.include_hidden = true
 	for child: String in dir.get_directories(): _remove_tree(path.path_join(child), staging_root)
 	for child: String in dir.get_files(): DirAccess.remove_absolute(path.path_join(child))
 	DirAccess.remove_absolute(path)
+
+
+static func _remove_installed_tree(path: String, allowed_root: String) -> bool:
+	if (path != allowed_root and not path.begins_with(allowed_root + "/")):
+		return false
+	var dir: DirAccess = DirAccess.open(path)
+	if dir == null: return false
+	dir.include_hidden = true
+	for child: String in dir.get_directories():
+		var child_path: String = path.path_join(child)
+		if dir.is_link(child):
+			if DirAccess.remove_absolute(child_path) != OK: return false
+		elif not _remove_installed_tree(child_path, allowed_root): return false
+	for child: String in dir.get_files():
+		if DirAccess.remove_absolute(path.path_join(child)) != OK: return false
+	dir = null
+	return DirAccess.remove_absolute(path) == OK
 
 
 static func _file_size(path: String) -> int:

--- a/mod/net/community_pack_installer.gd
+++ b/mod/net/community_pack_installer.gd
@@ -1,0 +1,536 @@
+extends Node
+# Downloads a GameBanana ZIP into a private staging area, validates its central
+# directory before allocating decompressed data, extracts only inert dub-pack
+# assets, and moves the complete folder into packs_voice in one rename.
+
+signal progress(received: int, total: int, status: String)
+signal finished(result: Dictionary)
+signal failed(message: String)
+
+const DOWNLOAD_ROOT: String = "user://community_pack_downloads"
+const REGISTRY_PATH: String = "user://community_pack_registry.json"
+const MANIFEST_NAME: String = ".tcv-community-pack.json"
+
+const MAX_ARCHIVE_BYTES: int = 1024 * 1024 * 1024
+const MAX_EXPANDED_BYTES: int = 4 * 1024 * 1024 * 1024
+const MAX_FILE_BYTES: int = 768 * 1024 * 1024
+const MAX_FILES: int = 4096
+const FREE_SPACE_MARGIN: int = 256 * 1024 * 1024
+
+const SAFE_EXTENSIONS: PackedStringArray = [
+	"wav", "mp3", "ogg", "ogv",
+	"ini", "cfg", "json", "txt", "md",
+	"png", "jpg", "jpeg", "webp", "bmp",
+]
+const AUDIO_EXTENSIONS: PackedStringArray = ["wav", "mp3", "ogg"]
+
+var _http: HTTPRequest
+var _busy: bool = false
+var _mod: Dictionary = {}
+var _file: Dictionary = {}
+var _download_path: String = ""
+
+
+func _ready() -> void:
+	_http = HTTPRequest.new()
+	_http.use_threads = true
+	_http.timeout = 0.0
+	_http.download_chunk_size = 256 * 1024
+	_http.request_completed.connect(_on_download_completed)
+	add_child(_http)
+	set_process(false)
+
+
+func _process(_delta: float) -> void:
+	if not _busy: return
+	progress.emit(_http.get_downloaded_bytes(), int(_file.get("size", 0)), "Downloading from GameBanana...")
+
+
+func is_busy() -> bool:
+	return _busy
+
+
+func cancel() -> void:
+	if not _busy: return
+	_http.cancel_request()
+	_busy = false
+	set_process(false)
+	_cleanup_download()
+	failed.emit("Download canceled.")
+
+
+func install(mod: Dictionary, file: Dictionary) -> void:
+	if _busy: return
+	var problem: String = installability_problem(file)
+	if not problem.is_empty():
+		failed.emit(problem)
+		return
+	var existing: String = installed_path(int(mod.get("id", 0)))
+	if not existing.is_empty():
+		finished.emit({"path": existing, "already_installed": true})
+		return
+	_mod = mod.duplicate(true)
+	_file = file.duplicate(true)
+	if DirAccess.make_dir_recursive_absolute(DOWNLOAD_ROOT) != OK:
+		failed.emit("Could not create the community-pack download folder.")
+		return
+	_download_path = DOWNLOAD_ROOT.path_join("%d.zip.part" % int(file["id"]))
+	if FileAccess.file_exists(_download_path): DirAccess.remove_absolute(_download_path)
+	_http.download_file = _download_path
+	_http.body_size_limit = MAX_ARCHIVE_BYTES
+	_busy = true
+	set_process(true)
+	progress.emit(0, int(file.get("size", 0)), "Connecting to GameBanana...")
+	var headers: PackedStringArray = [
+		"Accept: application/octet-stream",
+		"User-Agent: TCV-Multiplayer/%s" % str(Net.MOD_VERSION),
+	]
+	var error: Error = _http.request(str(file["url"]), headers)
+	if error != OK:
+		_fail("Could not start the download (%s)." % error_string(error))
+
+
+static func installability_problem(file: Dictionary) -> String:
+	var name: String = str(file.get("name", ""))
+	if name.get_extension().to_lower() != "zip":
+		return "This file is not a ZIP. RAR and 7z support is not available yet."
+	var size: int = int(file.get("size", 0))
+	if size <= 0: return "GameBanana did not report a valid file size."
+	if size > MAX_ARCHIVE_BYTES: return "This archive is larger than the 1 GB safety limit."
+	var url: String = str(file.get("url", ""))
+	if not url.begins_with("https://gamebanana.com/dl/"):
+		return "The download URL did not come from GameBanana."
+	var md5: String = str(file.get("md5", "")).to_lower()
+	if md5.length() != 32 or not _is_hex(md5):
+		return "GameBanana did not provide a usable checksum for this file."
+	if str(file.get("analysis_state", "")) != "done" or str(file.get("analysis_result", "")) != "ok":
+		return "GameBanana has not finished approving this archive."
+	if str(file.get("av_state", "")) != "done" or str(file.get("av_result", "")) != "clean":
+		return "GameBanana has not marked this archive clean."
+	if bool(file.get("archived", false)): return "This GameBanana file has been archived."
+	return ""
+
+
+func _on_download_completed(
+	result: int, response_code: int, _headers: PackedStringArray, _body: PackedByteArray
+) -> void:
+	set_process(false)
+	_http.download_file = ""
+	if not _busy: return
+	if result != HTTPRequest.RESULT_SUCCESS:
+		_fail("The archive download failed (%d)." % result)
+		return
+	if response_code < 200 or response_code >= 300:
+		_fail("GameBanana returned HTTP %d for the archive." % response_code)
+		return
+	_finish_download.call_deferred()
+
+
+func _finish_download() -> void:
+	if not _busy: return
+	var expected_size: int = int(_file.get("size", 0))
+	var actual_size: int = _file_size(_download_path)
+	if actual_size != expected_size:
+		_fail("The archive was incomplete: expected %s, received %s." % [
+			_format_bytes(expected_size), _format_bytes(actual_size)])
+		return
+	progress.emit(actual_size, expected_size, "Verifying the archive checksum...")
+	var actual_md5: String = FileAccess.get_md5(_download_path).to_lower()
+	if actual_md5 != str(_file.get("md5", "")).to_lower():
+		_fail("The downloaded archive failed its checksum. It was not installed.")
+		return
+
+	progress.emit(actual_size, expected_size, "Checking and installing the dub pack...")
+	var thread: = Thread.new()
+	# Resolve the game autoload on the main thread. The worker only receives an
+	# immutable path and then sticks to its own FileAccess/DirAccess instances.
+	var voice_root: String = str(FileManager.MODPACKS_VOICE)
+	var error: Error = thread.start(
+		_validate_and_extract.bind(_download_path, _mod, _file, voice_root, true))
+	if error != OK:
+		_fail("Could not start archive validation (%s)." % error_string(error))
+		return
+	while thread.is_alive(): await get_tree().process_frame
+	var extracted_value: Variant = thread.wait_to_finish()
+	if not extracted_value is Dictionary:
+		_fail("Archive validation stopped unexpectedly.")
+		return
+	var extracted: Dictionary = extracted_value
+	if extracted.has("error"):
+		_fail(str(extracted["error"]))
+		return
+	_busy = false
+	_cleanup_download()
+	progress.emit(expected_size, expected_size, "Installed.")
+	finished.emit(extracted)
+
+
+func _fail(message: String) -> void:
+	_busy = false
+	set_process(false)
+	_http.download_file = ""
+	_cleanup_download()
+	failed.emit(message)
+
+
+func _cleanup_download() -> void:
+	if (_download_path.begins_with(DOWNLOAD_ROOT + "/")
+		and FileAccess.file_exists(_download_path)):
+		DirAccess.remove_absolute(_download_path)
+	_download_path = ""
+
+
+static func _validate_and_extract(
+	archive: String, mod: Dictionary, file: Dictionary, voice_root_override: String = "",
+	use_registry: bool = true
+) -> Dictionary:
+	var indexed: Dictionary = inspect_zip(archive)
+	if indexed.has("error"): return indexed
+	var entries: Array[Dictionary] = []
+	for value: Variant in Array(indexed.get("entries", [])):
+		if value is Dictionary: entries.append(value)
+	var root: String = _find_dub_root(entries)
+	if root == String.chr(0):
+		return {"error": "No dub pack was found in the archive. A dub pack needs an OGV video and audio clips."}
+
+	var chosen: Array[Dictionary] = []
+	var total: int = 0
+	var audio_count: int = 0
+	var video_count: int = 0
+	var seen: Dictionary = {}
+	for entry: Dictionary in entries:
+		if bool(entry.get("directory", false)): continue
+		var path: String = str(entry["path"])
+		if not root.is_empty():
+			if not path.begins_with(root + "/"): continue
+			path = path.substr(root.length() + 1)
+		if _junk_path(path): continue
+		if not _safe_relative_path(path):
+			return {"error": "The archive contains an unsafe path: %s" % path}
+		var ext: String = path.get_extension().to_lower()
+		if not SAFE_EXTENSIONS.has(ext):
+			return {"error": "The dub pack contains a blocked file type: %s" % path}
+		var key: String = path.to_lower()
+		if seen.has(key): return {"error": "The archive writes the same path twice: %s" % path}
+		seen[key] = true
+		var size: int = int(entry["size"])
+		if size > MAX_FILE_BYTES:
+			return {"error": "%s is larger than the per-file safety limit." % path}
+		total += size
+		if total > MAX_EXPANDED_BYTES:
+			return {"error": "The extracted pack would exceed the 4 GB safety limit."}
+		if AUDIO_EXTENSIONS.has(ext): audio_count += 1
+		if ext == "ogv": video_count += 1
+		var selected: Dictionary = entry.duplicate()
+		selected["output_path"] = path
+		chosen.append(selected)
+	if chosen.is_empty() or audio_count == 0 or video_count == 0:
+		return {"error": "The archive did not contain a complete dub pack."}
+
+	var voice_root: String = (
+		str(FileManager.MODPACKS_VOICE) if voice_root_override.is_empty()
+		else voice_root_override).trim_suffix("/")
+	if DirAccess.make_dir_recursive_absolute(voice_root) != OK:
+		return {"error": "Could not create the game's packs_voice folder."}
+	var root_dir: DirAccess = DirAccess.open(voice_root)
+	if root_dir != null:
+		var free: int = root_dir.get_space_left()
+		if free > 0 and free < total + FREE_SPACE_MARGIN:
+			return {"error": "Not enough disk space to install this pack."}
+	# Stage beside the final pack. user:// may be on C: while the game and its
+	# external packs live on another drive; a rename across those volumes is not
+	# atomic and normally fails outright on Windows.
+	var staging_root: String = voice_root.path_join(".tcv-community-staging")
+	if DirAccess.make_dir_recursive_absolute(staging_root) != OK:
+		return {"error": "Could not create the community-pack staging folder."}
+
+	var folder_name: String = _safe_folder_name(str(mod.get("name", "Dub pack")), int(mod.get("id", 0)))
+	var destination: String = voice_root.path_join(folder_name)
+	var registry: Dictionary = load_registry() if use_registry else {}
+	var registered: Dictionary = _as_dictionary(registry.get(str(mod.get("id", 0)), {}))
+	var registered_path: String = str(registered.get("path", ""))
+	if not registered_path.is_empty() and DirAccess.dir_exists_absolute(registered_path):
+		return {"path": registered_path, "already_installed": true}
+	var suffix: int = 2
+	while DirAccess.dir_exists_absolute(destination):
+		destination = voice_root.path_join("%s (%d)" % [folder_name, suffix])
+		suffix += 1
+
+	var staging: String = staging_root.path_join(
+		"%d-%d" % [int(mod.get("id", 0)), Time.get_ticks_usec()])
+	if DirAccess.make_dir_recursive_absolute(staging) != OK:
+		return {"error": "Could not create a temporary installation folder."}
+	var zip: = ZIPReader.new()
+	var open_error: Error = zip.open(archive)
+	if open_error != OK:
+		_remove_tree(staging, staging_root)
+		return {"error": "Godot could not open this ZIP (%s)." % error_string(open_error)}
+	for entry: Dictionary in chosen:
+		var output_path: String = staging.path_join(str(entry["output_path"]))
+		if DirAccess.make_dir_recursive_absolute(output_path.get_base_dir()) != OK:
+			zip.close()
+			_remove_tree(staging, staging_root)
+			return {"error": "Could not create a folder while extracting the pack."}
+		var bytes: PackedByteArray = zip.read_file(str(entry["zip_path"]))
+		if bytes.size() != int(entry["size"]):
+			zip.close()
+			_remove_tree(staging, staging_root)
+			return {"error": "The ZIP entry %s did not extract to its declared size." % str(entry["output_path"])}
+		var output: FileAccess = FileAccess.open(output_path, FileAccess.WRITE)
+		if output == null:
+			zip.close()
+			_remove_tree(staging, staging_root)
+			return {"error": "Could not write %s." % str(entry["output_path"])}
+		output.store_buffer(bytes)
+		output.close()
+	zip.close()
+
+	var manifest: Dictionary = {
+		"schema": 1,
+		"provider": "gamebanana",
+		"mod_id": int(mod.get("id", 0)),
+		"file_id": int(file.get("id", 0)),
+		"name": str(mod.get("name", "Dub pack")),
+		"author": str(mod.get("author", "Unknown creator")),
+		"profile_url": str(mod.get("profile_url", "")),
+		"archive_name": str(file.get("name", "")),
+		"archive_md5": str(file.get("md5", "")),
+		"installed_unix": int(Time.get_unix_time_from_system()),
+	}
+	var manifest_file: FileAccess = FileAccess.open(staging.path_join(MANIFEST_NAME), FileAccess.WRITE)
+	if manifest_file == null:
+		_remove_tree(staging, staging_root)
+		return {"error": "Could not write the installed-pack manifest."}
+	manifest_file.store_string(JSON.stringify(manifest, "  "))
+	manifest_file.close()
+
+	var move_error: Error = DirAccess.rename_absolute(staging, destination)
+	if move_error != OK:
+		_remove_tree(staging, staging_root)
+		return {"error": "Could not move the verified pack into packs_voice (%s)." % error_string(move_error)}
+	if not use_registry:
+		return {"path": destination, "files": chosen.size(), "bytes": total}
+	registry[str(mod.get("id", 0))] = {
+		"path": destination,
+		"file_id": int(file.get("id", 0)),
+		"md5": str(file.get("md5", "")),
+		"name": str(mod.get("name", "Dub pack")),
+	}
+	if not save_registry(registry):
+		# Installation is still complete; the embedded manifest lets a later run
+		# rediscover it even if this convenience index could not be written.
+		return {"path": destination, "warning": "Installed, but could not update the local pack index."}
+	return {"path": destination, "files": chosen.size(), "bytes": total}
+
+
+static func inspect_zip(path: String) -> Dictionary:
+	var input: FileAccess = FileAccess.open(path, FileAccess.READ)
+	if input == null: return {"error": "Could not open the downloaded archive."}
+	var length: int = input.get_length()
+	if length < 22 or length > MAX_ARCHIVE_BYTES:
+		input.close()
+		return {"error": "The downloaded ZIP has an invalid size."}
+	var tail_size: int = mini(length, 65557)
+	input.seek(length - tail_size)
+	var tail: PackedByteArray = input.get_buffer(tail_size)
+	var eocd: int = -1
+	for i: int in range(tail.size() - 22, -1, -1):
+		if tail.decode_u32(i) == 0x06054b50:
+			eocd = i
+			break
+	if eocd < 0:
+		input.close()
+		return {"error": "The archive has no readable ZIP directory."}
+	var entry_count: int = tail.decode_u16(eocd + 10)
+	var directory_size: int = tail.decode_u32(eocd + 12)
+	var directory_offset: int = tail.decode_u32(eocd + 16)
+	if (entry_count == 0xffff or directory_size == 0xffffffff or directory_offset == 0xffffffff
+		or entry_count <= 0 or entry_count > MAX_FILES
+		or directory_offset < 0 or directory_size < 0
+		or directory_offset + directory_size > length):
+		input.close()
+		return {"error": "ZIP64 or an invalid archive directory is not supported."}
+	input.seek(directory_offset)
+	var entries: Array[Dictionary] = []
+	var expanded: int = 0
+	for _index: int in entry_count:
+		var header: PackedByteArray = input.get_buffer(46)
+		if header.size() != 46 or header.decode_u32(0) != 0x02014b50:
+			input.close()
+			return {"error": "The ZIP directory is corrupt."}
+		var flags: int = header.decode_u16(8)
+		var method: int = header.decode_u16(10)
+		var compressed: int = header.decode_u32(20)
+		var size: int = header.decode_u32(24)
+		var name_length: int = header.decode_u16(28)
+		var extra_length: int = header.decode_u16(30)
+		var comment_length: int = header.decode_u16(32)
+		var external_attributes: int = header.decode_u32(38)
+		if (compressed == 0xffffffff or size == 0xffffffff or name_length <= 0
+			or name_length > 4096 or extra_length > 65535 or comment_length > 65535):
+			input.close()
+			return {"error": "The ZIP uses unsupported ZIP64 entry metadata."}
+		var name_bytes: PackedByteArray = input.get_buffer(name_length)
+		if name_bytes.size() != name_length:
+			input.close()
+			return {"error": "A ZIP filename is truncated."}
+		input.seek(input.get_position() + extra_length + comment_length)
+		var zip_path: String = name_bytes.get_string_from_utf8()
+		var normalized: String = zip_path.replace("\\", "/").trim_prefix("./")
+		var directory: bool = normalized.ends_with("/")
+		var unix_type: int = (external_attributes >> 16) & 0xf000
+		if unix_type == 0xa000:
+			input.close()
+			return {"error": "The archive contains a symbolic link, which is not allowed."}
+		if (flags & 1) != 0:
+			input.close()
+			return {"error": "Password-protected ZIP entries are not supported."}
+		if not directory and method != 0 and method != 8:
+			input.close()
+			return {"error": "The ZIP uses an unsupported compression method."}
+		if not directory:
+			if size > MAX_FILE_BYTES:
+				input.close()
+				return {"error": "%s is too large to extract safely." % normalized}
+			expanded += size
+			if expanded > MAX_EXPANDED_BYTES:
+				input.close()
+				return {"error": "The archive expands beyond the 4 GB safety limit."}
+			if size > 16 * 1024 * 1024 and (compressed <= 0 or size / compressed > 200):
+				input.close()
+				return {"error": "%s has an unsafe compression ratio." % normalized}
+		entries.append({
+			"zip_path": zip_path,
+			"path": normalized.trim_suffix("/"),
+			"directory": directory,
+			"size": size,
+			"compressed": compressed,
+		})
+	input.close()
+	return {"entries": entries, "expanded_bytes": expanded}
+
+
+static func _find_dub_root(entries: Array[Dictionary]) -> String:
+	var best: String = String.chr(0)
+	var best_audio: int = -1
+	for entry: Dictionary in entries:
+		if bool(entry.get("directory", false)): continue
+		var path: String = str(entry.get("path", ""))
+		if path.get_extension().to_lower() != "ogv": continue
+		var candidate: String = path.get_base_dir()
+		if candidate == ".": candidate = ""
+		var audio: int = 0
+		for other: Dictionary in entries:
+			if bool(other.get("directory", false)): continue
+			var other_path: String = str(other.get("path", ""))
+			if not candidate.is_empty() and not other_path.begins_with(candidate + "/"): continue
+			if AUDIO_EXTENSIONS.has(other_path.get_extension().to_lower()): audio += 1
+		if audio > best_audio or (audio == best_audio and candidate.length() > best.length()):
+			best = candidate
+			best_audio = audio
+	return best if best_audio > 0 else String.chr(0)
+
+
+static func installed_path(mod_id: int) -> String:
+	if mod_id <= 0: return ""
+	var registry: Dictionary = load_registry()
+	var record: Dictionary = _as_dictionary(registry.get(str(mod_id), {}))
+	var path: String = str(record.get("path", ""))
+	if not path.is_empty() and DirAccess.dir_exists_absolute(path): return path
+	# The per-pack manifest is authoritative. Rebuild the convenience index if
+	# it was deleted or an installed folder was moved within packs_voice.
+	var voice_root: String = str(FileManager.MODPACKS_VOICE).trim_suffix("/")
+	if not DirAccess.dir_exists_absolute(voice_root): return ""
+	for folder: String in DirAccess.get_directories_at(voice_root):
+		var candidate: String = voice_root.path_join(folder)
+		var manifest_path: String = candidate.path_join(MANIFEST_NAME)
+		if not FileAccess.file_exists(manifest_path): continue
+		var parsed: Variant = JSON.parse_string(FileAccess.get_file_as_string(manifest_path))
+		if not parsed is Dictionary or int(parsed.get("mod_id", 0)) != mod_id: continue
+		registry[str(mod_id)] = {
+			"path": candidate,
+			"file_id": int(parsed.get("file_id", 0)),
+			"md5": str(parsed.get("archive_md5", "")),
+			"name": str(parsed.get("name", folder)),
+		}
+		save_registry(registry)
+		return candidate
+	return ""
+
+
+static func load_registry() -> Dictionary:
+	if not FileAccess.file_exists(REGISTRY_PATH): return {}
+	var parsed: Variant = JSON.parse_string(FileAccess.get_file_as_string(REGISTRY_PATH))
+	return parsed if parsed is Dictionary else {}
+
+
+static func save_registry(registry: Dictionary) -> bool:
+	var output: FileAccess = FileAccess.open(REGISTRY_PATH, FileAccess.WRITE)
+	if output == null: return false
+	output.store_string(JSON.stringify(registry, "  "))
+	output.close()
+	return true
+
+
+static func _safe_relative_path(path: String) -> bool:
+	if (path.is_empty() or path.length() > 512 or path.begins_with("/")
+		or path.contains(String.chr(0))):
+		return false
+	if path.length() >= 2 and path.substr(1, 1) == ":": return false
+	for part: String in path.replace("\\", "/").split("/", false):
+		if part.is_empty() or part == "." or part == "..": return false
+	return true
+
+
+static func _junk_path(path: String) -> bool:
+	var lower: String = path.to_lower()
+	return (lower.begins_with("__macosx/") or lower.ends_with("/.ds_store")
+		or lower == ".ds_store" or lower.ends_with("/thumbs.db") or lower == "thumbs.db"
+		or lower.ends_with("/desktop.ini") or lower == "desktop.ini")
+
+
+static func _safe_folder_name(value: String, mod_id: int) -> String:
+	var out: String = ""
+	for i: int in value.length():
+		var c: String = value.substr(i, 1)
+		if ("abcdefghijklmnopqrstuvwxyz0123456789".contains(c.to_lower())
+			or " -_().[]".contains(c)):
+			out += c
+		elif not out.ends_with(" "): out += " "
+	out = out.strip_edges().substr(0, 80).strip_edges()
+	if out.is_empty(): out = "Dub pack"
+	return "%s [GB-%d]" % [out, mod_id]
+
+
+static func _remove_tree(path: String, staging_root: String) -> void:
+	if not path.begins_with(staging_root + "/") or not DirAccess.dir_exists_absolute(path): return
+	var dir: DirAccess = DirAccess.open(path)
+	if dir == null: return
+	for child: String in dir.get_directories(): _remove_tree(path.path_join(child), staging_root)
+	for child: String in dir.get_files(): DirAccess.remove_absolute(path.path_join(child))
+	DirAccess.remove_absolute(path)
+
+
+static func _file_size(path: String) -> int:
+	var input: FileAccess = FileAccess.open(path, FileAccess.READ)
+	if input == null: return -1
+	var size: int = input.get_length()
+	input.close()
+	return size
+
+
+static func _is_hex(value: String) -> bool:
+	for i: int in value.length():
+		if not "0123456789abcdef".contains(value.substr(i, 1).to_lower()): return false
+	return true
+
+
+static func _as_dictionary(value: Variant) -> Dictionary:
+	return value if value is Dictionary else {}
+
+
+static func _format_bytes(bytes: int) -> String:
+	if bytes >= 1024 * 1024 * 1024: return "%.2f GB" % (float(bytes) / 1073741824.0)
+	if bytes >= 1024 * 1024: return "%.1f MB" % (float(bytes) / 1048576.0)
+	if bytes >= 1024: return "%.1f KB" % (float(bytes) / 1024.0)
+	return "%d bytes" % bytes

--- a/mod/net/community_pack_queue.gd
+++ b/mod/net/community_pack_queue.gd
@@ -6,6 +6,7 @@ extends Node
 signal changed
 
 const INSTALLER_SCRIPT: Script = preload("res://net/community_pack_installer.gd")
+const SETTINGS_PATH: String = "user://community_pack_settings.json"
 
 var _net: Node
 var _installer: Node
@@ -15,6 +16,7 @@ var _cancel_requested: bool = false
 var _last_online: bool = false
 var _poll_elapsed: float = 0.0
 var _last_progress_emit_msec: int = 0
+var _allow_online_downloads: bool = false
 
 
 func configure(net: Node) -> void:
@@ -24,6 +26,7 @@ func configure(net: Node) -> void:
 
 func _ready() -> void:
 	process_mode = Node.PROCESS_MODE_ALWAYS
+	_load_settings()
 	_installer = INSTALLER_SCRIPT.new()
 	_installer.progress.connect(_on_progress)
 	_installer.finished.connect(_on_finished)
@@ -39,7 +42,19 @@ func _process(delta: float) -> void:
 	if online != _last_online:
 		_last_online = online
 		changed.emit()
-	if _active_id.is_empty() and not online: _pump()
+	if _active_id.is_empty() and (not online or _allow_online_downloads): _pump()
+
+
+func allow_online_downloads() -> bool:
+	return _allow_online_downloads
+
+
+func set_allow_online_downloads(value: bool) -> void:
+	if _allow_online_downloads == value: return
+	_allow_online_downloads = value
+	_save_settings()
+	changed.emit()
+	if value: _pump.call_deferred()
 
 
 func enqueue(mod: Dictionary, file: Dictionary) -> String:
@@ -140,7 +155,7 @@ static func job_id(mod_id: int, file_id: int) -> String:
 
 func _pump() -> void:
 	if not _active_id.is_empty() or _installer.is_busy(): return
-	if _net != null and _net.is_online(): return
+	if _net != null and _net.is_online() and not _allow_online_downloads: return
 	for index: int in _jobs.size():
 		if str(_jobs[index].get("state", "")) != "queued": continue
 		_active_id = str(_jobs[index]["id"])
@@ -202,3 +217,17 @@ func _job_index(id: String) -> int:
 	for index: int in _jobs.size():
 		if str(_jobs[index].get("id", "")) == id: return index
 	return -1
+
+
+func _load_settings() -> void:
+	if not FileAccess.file_exists(SETTINGS_PATH): return
+	var parsed: Variant = JSON.parse_string(FileAccess.get_file_as_string(SETTINGS_PATH))
+	if parsed is Dictionary:
+		_allow_online_downloads = bool(parsed.get("allow_online_downloads", false))
+
+
+func _save_settings() -> void:
+	var output: FileAccess = FileAccess.open(SETTINGS_PATH, FileAccess.WRITE)
+	if output == null: return
+	output.store_string(JSON.stringify({"allow_online_downloads": _allow_online_downloads}, "  "))
+	output.close()

--- a/mod/net/community_pack_queue.gd
+++ b/mod/net/community_pack_queue.gd
@@ -1,0 +1,204 @@
+extends Node
+# Session-long download queue. It lives under the Net autoload rather than the
+# catalog screen, so closing the browser or entering an offline game does not
+# tear down a large download.
+
+signal changed
+
+const INSTALLER_SCRIPT: Script = preload("res://net/community_pack_installer.gd")
+
+var _net: Node
+var _installer: Node
+var _jobs: Array[Dictionary] = []
+var _active_id: String = ""
+var _cancel_requested: bool = false
+var _last_online: bool = false
+var _poll_elapsed: float = 0.0
+var _last_progress_emit_msec: int = 0
+
+
+func configure(net: Node) -> void:
+	_net = net
+	_last_online = _net.is_online()
+
+
+func _ready() -> void:
+	process_mode = Node.PROCESS_MODE_ALWAYS
+	_installer = INSTALLER_SCRIPT.new()
+	_installer.progress.connect(_on_progress)
+	_installer.finished.connect(_on_finished)
+	_installer.failed.connect(_on_failed)
+	add_child(_installer)
+
+
+func _process(delta: float) -> void:
+	_poll_elapsed += delta
+	if _poll_elapsed < 0.5: return
+	_poll_elapsed = 0.0
+	var online: bool = _net != null and _net.is_online()
+	if online != _last_online:
+		_last_online = online
+		changed.emit()
+	if _active_id.is_empty() and not online: _pump()
+
+
+func enqueue(mod: Dictionary, file: Dictionary) -> String:
+	var mod_id: int = int(mod.get("id", 0))
+	var file_id: int = int(file.get("id", 0))
+	if mod_id <= 0 or file_id <= 0: return ""
+	var id: String = job_id(mod_id, file_id)
+	var index: int = _job_index(id)
+	if index >= 0:
+		var state: String = str(_jobs[index].get("state", ""))
+		if state in ["queued", "downloading", "verifying", "installing"]: return id
+		_jobs.remove_at(index)
+	_jobs.append({
+		"id": id,
+		"mod": mod.duplicate(true),
+		"file": file.duplicate(true),
+		"state": "queued",
+		"received": 0,
+		"total": int(file.get("size", 0)),
+		"status": "Queued",
+		"error": "",
+		"result": {},
+	})
+	changed.emit()
+	_pump.call_deferred()
+	return id
+
+
+func cancel(id: String) -> void:
+	var index: int = _job_index(id)
+	if index < 0: return
+	if id == _active_id:
+		if str(_jobs[index].get("state", "")) != "downloading": return
+		_cancel_requested = true
+		_installer.cancel()
+		return
+	if str(_jobs[index].get("state", "")) == "queued":
+		_jobs[index]["state"] = "canceled"
+		_jobs[index]["status"] = "Canceled"
+		changed.emit()
+
+
+func dismiss(id: String) -> void:
+	var index: int = _job_index(id)
+	if index < 0: return
+	if str(_jobs[index].get("state", "")) in ["finished", "failed", "canceled"]:
+		_jobs.remove_at(index)
+		changed.emit()
+
+
+func dismiss_for_mod(mod_id: int) -> void:
+	var removed: bool = false
+	for index: int in range(_jobs.size() - 1, -1, -1):
+		if int(_jobs[index].get("mod", {}).get("id", 0)) != mod_id: continue
+		if str(_jobs[index].get("state", "")) not in ["finished", "failed", "canceled"]: continue
+		_jobs.remove_at(index)
+		removed = true
+	if removed: changed.emit()
+
+
+func retry(id: String) -> void:
+	var record: Dictionary = get_job(id)
+	if record.is_empty(): return
+	if str(record.get("state", "")) not in ["failed", "canceled"]: return
+	enqueue(record.get("mod", {}), record.get("file", {}))
+
+
+func get_job(id: String) -> Dictionary:
+	var index: int = _job_index(id)
+	return _jobs[index].duplicate(true) if index >= 0 else {}
+
+
+func get_jobs() -> Array[Dictionary]:
+	var out: Array[Dictionary] = []
+	for record: Dictionary in _jobs: out.append(record.duplicate(true))
+	return out
+
+
+func job_for(mod_id: int, file_id: int) -> Dictionary:
+	return get_job(job_id(mod_id, file_id))
+
+
+func active_count() -> int:
+	var total: int = 0
+	for record: Dictionary in _jobs:
+		if str(record.get("state", "")) in ["queued", "downloading", "verifying", "installing"]:
+			total += 1
+	return total
+
+
+func is_busy() -> bool:
+	return active_count() > 0
+
+
+static func job_id(mod_id: int, file_id: int) -> String:
+	return "%d:%d" % [mod_id, file_id]
+
+
+func _pump() -> void:
+	if not _active_id.is_empty() or _installer.is_busy(): return
+	if _net != null and _net.is_online(): return
+	for index: int in _jobs.size():
+		if str(_jobs[index].get("state", "")) != "queued": continue
+		_active_id = str(_jobs[index]["id"])
+		_cancel_requested = false
+		_jobs[index]["state"] = "downloading"
+		_jobs[index]["status"] = "Connecting to GameBanana..."
+		changed.emit()
+		_installer.install(_jobs[index]["mod"], _jobs[index]["file"])
+		return
+
+
+func _on_progress(received: int, total: int, status: String) -> void:
+	var index: int = _job_index(_active_id)
+	if index < 0: return
+	var previous_state: String = str(_jobs[index].get("state", ""))
+	_jobs[index]["received"] = received
+	_jobs[index]["total"] = total
+	_jobs[index]["status"] = status
+	var lower: String = status.to_lower()
+	if lower.contains("verifying"): _jobs[index]["state"] = "verifying"
+	elif lower.contains("installing") or lower.contains("checking"):
+		_jobs[index]["state"] = "installing"
+	else: _jobs[index]["state"] = "downloading"
+	var now: int = Time.get_ticks_msec()
+	if (str(_jobs[index].get("state", "")) != previous_state
+		or now - _last_progress_emit_msec >= 100 or received >= total):
+		_last_progress_emit_msec = now
+		changed.emit()
+
+
+func _on_finished(result: Dictionary) -> void:
+	var index: int = _job_index(_active_id)
+	if index >= 0:
+		_jobs[index]["state"] = "finished"
+		_jobs[index]["status"] = "Installed"
+		_jobs[index]["received"] = int(_jobs[index].get("total", 0))
+		_jobs[index]["result"] = result.duplicate(true)
+	var completed_id: String = _active_id
+	_active_id = ""
+	_cancel_requested = false
+	if _net != null: _net.community_pack_library_changed()
+	changed.emit()
+	if not completed_id.is_empty(): _pump.call_deferred()
+
+
+func _on_failed(message: String) -> void:
+	var index: int = _job_index(_active_id)
+	if index >= 0:
+		_jobs[index]["state"] = "canceled" if _cancel_requested else "failed"
+		_jobs[index]["status"] = "Canceled" if _cancel_requested else "Download failed"
+		_jobs[index]["error"] = "" if _cancel_requested else message
+	_active_id = ""
+	_cancel_requested = false
+	changed.emit()
+	_pump.call_deferred()
+
+
+func _job_index(id: String) -> int:
+	for index: int in _jobs.size():
+		if str(_jobs[index].get("id", "")) == id: return index
+	return -1

--- a/mod/net/gamebanana_client.gd
+++ b/mod/net/gamebanana_client.gd
@@ -15,6 +15,7 @@ const API_BODY_LIMIT: int = 8 * 1024 * 1024
 const INDEX_URL: String = "https://gamebanana.com/apiv13/Mod/Index"
 const SEARCH_URL: String = "https://gamebanana.com/apiv13/Util/Search/Results"
 const DETAIL_URL: String = "https://gamebanana.com/apiv11/Mod/%d"
+const SEARCH_FIELDS: String = "name,description,owner,credits"
 
 var _http: HTTPRequest
 var _request_kind: String = ""
@@ -57,17 +58,23 @@ func search(query: String, page: int, sort: String = "best_match", force: bool =
 	if clean.is_empty():
 		fetch_page(page, "Generic_Newest", force)
 		return
+	if clean.length() < 2:
+		request_failed.emit("Search for at least 2 characters.")
+		return
 	_request_kind = "search"
 	_request_page = maxi(1, page)
-	var url: String = (SEARCH_URL
+	_start(build_search_url(clean, _request_page, sort), force)
+
+
+static func build_search_url(query: String, page: int, sort: String = "best_match") -> String:
+	return (SEARCH_URL
 		+ "?_sModelName=Mod"
 		+ "&_sOrder=%s" % sort.uri_encode()
 		+ "&_idGameRow=%d" % GAME_ID
-		+ "&_sSearchString=%s" % clean.uri_encode()
-		+ "&_csvFields=name%%2Cdescription%%2Cowner%%2Ccredits"
+		+ "&_sSearchString=%s" % query.strip_edges().uri_encode()
+		+ "&_csvFields=%s" % SEARCH_FIELDS.uri_encode()
 		+ "&_nPerpage=%d" % PAGE_SIZE
-		+ "&_nPage=%d" % _request_page)
-	_start(url, force)
+		+ "&_nPage=%d" % maxi(1, page))
 
 
 func fetch_detail(mod_id: int, force: bool = false) -> void:
@@ -100,7 +107,7 @@ func _on_request_completed(
 		request_failed.emit("GameBanana request failed (%d)." % result)
 		return
 	if response_code < 200 or response_code >= 300:
-		request_failed.emit("GameBanana returned HTTP %d." % response_code)
+		request_failed.emit(_http_error_message(response_code, body.get_string_from_utf8()))
 		return
 	var text: String = body.get_string_from_utf8()
 	if kind == "detail":
@@ -111,6 +118,20 @@ func _on_request_completed(
 		var page: Dictionary = parse_page_json(text, _request_page, kind == "search")
 		if page.has("error"): request_failed.emit(str(page["error"]))
 		else: page_loaded.emit(page)
+
+
+static func _http_error_message(response_code: int, text: String) -> String:
+	var parsed: Variant = JSON.parse_string(text)
+	if parsed is Dictionary:
+		var error_data: Dictionary = _as_dictionary(parsed.get("_aErrorData", {}))
+		for value: Variant in error_data.values():
+			if value is Dictionary:
+				var message: String = str(value.get("_sErrorMessage", "")).strip_edges()
+				if not message.is_empty():
+					return "GameBanana rejected the request: %s." % message.trim_suffix(".")
+		var code: String = str(parsed.get("_sErrorCode", "")).strip_edges()
+		if not code.is_empty(): return "GameBanana rejected the request: %s." % code
+	return "GameBanana returned HTTP %d." % response_code
 
 
 static func parse_page_json(text: String, page: int = 1, dub_only: bool = false) -> Dictionary:

--- a/mod/net/gamebanana_client.gd
+++ b/mod/net/gamebanana_client.gd
@@ -1,0 +1,231 @@
+extends Node
+# Small read-only client for the public GameBanana catalog. The browser talks to
+# this node instead of baking response shapes into its controls, which also
+# gives the parsers somewhere deterministic to be tested without the network.
+
+signal page_loaded(payload: Dictionary)
+signal detail_loaded(payload: Dictionary)
+signal request_failed(message: String)
+
+const GAME_ID: int = 20674
+const DUB_CATEGORY_ID: int = 44064
+const PAGE_SIZE: int = 18
+const API_BODY_LIMIT: int = 8 * 1024 * 1024
+
+const INDEX_URL: String = "https://gamebanana.com/apiv13/Mod/Index"
+const SEARCH_URL: String = "https://gamebanana.com/apiv13/Util/Search/Results"
+const DETAIL_URL: String = "https://gamebanana.com/apiv11/Mod/%d"
+
+var _http: HTTPRequest
+var _request_kind: String = ""
+var _request_page: int = 1
+
+
+func _ready() -> void:
+	_http = HTTPRequest.new()
+	_http.use_threads = true
+	_http.timeout = 15.0
+	_http.body_size_limit = API_BODY_LIMIT
+	_http.request_completed.connect(_on_request_completed)
+	add_child(_http)
+
+
+func is_busy() -> bool:
+	return not _request_kind.is_empty()
+
+
+func cancel() -> void:
+	if is_busy(): _http.cancel_request()
+	_request_kind = ""
+
+
+func fetch_page(page: int, sort: String = "Generic_Newest", force: bool = false) -> void:
+	if is_busy(): return
+	_request_kind = "page"
+	_request_page = maxi(1, page)
+	var url: String = (INDEX_URL
+		+ "?_nPerpage=%d" % PAGE_SIZE
+		+ "&_aFilters%%5BGeneric_Category%%5D=%d" % DUB_CATEGORY_ID
+		+ "&_nPage=%d" % _request_page
+		+ "&_sSort=%s" % sort.uri_encode())
+	_start(url, force)
+
+
+func search(query: String, page: int, sort: String = "best_match", force: bool = false) -> void:
+	if is_busy(): return
+	var clean: String = query.strip_edges()
+	if clean.is_empty():
+		fetch_page(page, "Generic_Newest", force)
+		return
+	_request_kind = "search"
+	_request_page = maxi(1, page)
+	var url: String = (SEARCH_URL
+		+ "?_sModelName=Mod"
+		+ "&_sOrder=%s" % sort.uri_encode()
+		+ "&_idGameRow=%d" % GAME_ID
+		+ "&_sSearchString=%s" % clean.uri_encode()
+		+ "&_csvFields=name%%2Cdescription%%2Cowner%%2Ccredits"
+		+ "&_nPerpage=%d" % PAGE_SIZE
+		+ "&_nPage=%d" % _request_page)
+	_start(url, force)
+
+
+func fetch_detail(mod_id: int, force: bool = false) -> void:
+	if is_busy() or mod_id <= 0: return
+	_request_kind = "detail"
+	var fields: String = ("_idRow,_sName,_sText,_sDescription,_sVersion,_aFiles,"
+		+ "_sProfileUrl,_aSubmitter,_aRootCategory,_aPreviewMedia,_bIsObsolete")
+	var url: String = (DETAIL_URL % mod_id) + "?_csvProperties=" + fields.uri_encode()
+	_start(url, force)
+
+
+func _start(url: String, force: bool) -> void:
+	var headers: PackedStringArray = [
+		"Accept: application/json",
+		"User-Agent: TCV-Multiplayer/%s" % str(Net.MOD_VERSION),
+	]
+	if force: headers.append("Cache-Control: no-cache")
+	var error: Error = _http.request(url, headers)
+	if error != OK:
+		_request_kind = ""
+		request_failed.emit("Could not start the GameBanana request (%s)." % error_string(error))
+
+
+func _on_request_completed(
+	result: int, response_code: int, _headers: PackedStringArray, body: PackedByteArray
+) -> void:
+	var kind: String = _request_kind
+	_request_kind = ""
+	if result != HTTPRequest.RESULT_SUCCESS:
+		request_failed.emit("GameBanana request failed (%d)." % result)
+		return
+	if response_code < 200 or response_code >= 300:
+		request_failed.emit("GameBanana returned HTTP %d." % response_code)
+		return
+	var text: String = body.get_string_from_utf8()
+	if kind == "detail":
+		var detail: Dictionary = parse_detail_json(text)
+		if detail.has("error"): request_failed.emit(str(detail["error"]))
+		else: detail_loaded.emit(detail)
+	else:
+		var page: Dictionary = parse_page_json(text, _request_page, kind == "search")
+		if page.has("error"): request_failed.emit(str(page["error"]))
+		else: page_loaded.emit(page)
+
+
+static func parse_page_json(text: String, page: int = 1, dub_only: bool = false) -> Dictionary:
+	var parsed: Variant = JSON.parse_string(text)
+	if not parsed is Dictionary: return {"error": "GameBanana returned malformed catalog data."}
+	var root: Dictionary = parsed
+	if root.has("_sErrorCode"):
+		return {"error": "GameBanana rejected the catalog request: %s" % str(root["_sErrorCode"])}
+	var metadata: Dictionary = _as_dictionary(root.get("_aMetadata", {}))
+	var records: Array[Dictionary] = []
+	for value: Variant in _as_array(root.get("_aRecords", [])):
+		if not value is Dictionary: continue
+		var record: Dictionary = _normalize_record(value)
+		if record.is_empty(): continue
+		if dub_only and str(record.get("category", "")).to_lower() != "dub mode": continue
+		records.append(record)
+	return {
+		"page": maxi(1, page),
+		"records": records,
+		"total": maxi(0, int(metadata.get("_nRecordCount", records.size()))),
+		"complete": bool(metadata.get("_bIsComplete", records.is_empty())),
+	}
+
+
+static func parse_detail_json(text: String) -> Dictionary:
+	var parsed: Variant = JSON.parse_string(text)
+	if not parsed is Dictionary: return {"error": "GameBanana returned malformed pack data."}
+	var root: Dictionary = parsed
+	if root.has("_sErrorCode"):
+		return {"error": "GameBanana rejected the pack request: %s" % str(root["_sErrorCode"])}
+	var detail: Dictionary = _normalize_record(root)
+	if detail.is_empty(): return {"error": "The pack details did not contain a valid ID or name."}
+	detail["description"] = _plain_text(str(root.get("_sText", root.get("_sDescription", ""))))
+	var files: Array[Dictionary] = []
+	for value: Variant in _as_array(root.get("_aFiles", [])):
+		if not value is Dictionary: continue
+		var item: Dictionary = value
+		var file_id: int = int(item.get("_idRow", 0))
+		var name: String = str(item.get("_sFile", "")).strip_edges()
+		var url: String = str(item.get("_sDownloadUrl", ""))
+		if file_id <= 0 or name.is_empty() or not url.begins_with("https://gamebanana.com/dl/"):
+			continue
+		files.append({
+			"id": file_id,
+			"name": name,
+			"size": maxi(0, int(item.get("_nFilesize", 0))),
+			"url": url,
+			"md5": str(item.get("_sMd5Checksum", "")).to_lower(),
+			"analysis_state": str(item.get("_sAnalysisState", "")),
+			"analysis_result": str(item.get("_sAnalysisResult", "")),
+			"analysis_text": str(item.get("_sAnalysisResultVerbose", "")),
+			"av_state": str(item.get("_sAvState", "")),
+			"av_result": str(item.get("_sAvResult", "")),
+			"archived": bool(item.get("_bIsArchived", false)),
+			"version": str(item.get("_sVersion", "")),
+			"description": _plain_text(str(item.get("_sDescription", ""))),
+		})
+	detail["files"] = files
+	return detail
+
+
+static func _normalize_record(value: Dictionary) -> Dictionary:
+	var mod_id: int = int(value.get("_idRow", 0))
+	var name: String = str(value.get("_sName", "")).strip_edges()
+	if mod_id <= 0 or name.is_empty(): return {}
+	var author: Dictionary = _as_dictionary(value.get("_aSubmitter", {}))
+	var category: Dictionary = _as_dictionary(value.get("_aRootCategory", {}))
+	var subcategory: Dictionary = _as_dictionary(value.get("_aSubCategory", {}))
+	return {
+		"id": mod_id,
+		"name": name,
+		"profile_url": str(value.get("_sProfileUrl", "https://gamebanana.com/mods/%d" % mod_id)),
+		"author": str(author.get("_sName", "Unknown creator")),
+		"author_url": str(author.get("_sProfileUrl", "")),
+		"category": str(category.get("_sName", "")),
+		"subcategory": str(subcategory.get("_sName", "")),
+		"version": str(value.get("_sVersion", "")),
+		"image_url": _preview_url(value),
+		"modified": int(value.get("_tsDateModified", value.get("_tsDateAdded", 0))),
+		"obsolete": bool(value.get("_bIsObsolete", false)),
+		"content_rated": bool(value.get("_bHasContentRatings", false)),
+		"pay_type": str(value.get("_sPayType", "free")),
+	}
+
+
+static func _preview_url(value: Dictionary) -> String:
+	var content: Dictionary = _as_dictionary(value.get("_aPreviewContent", {}))
+	var shot: Dictionary = _as_dictionary(content.get("screenshot", {}))
+	if not shot.is_empty():
+		var file: String = str(shot.get("_sFile530", shot.get("_sFile220", shot.get("_sFile", ""))))
+		var base: String = str(shot.get("_sBaseUrl", "")).trim_suffix("/")
+		if not base.is_empty() and not file.is_empty(): return base + "/" + file
+	var media: Dictionary = _as_dictionary(value.get("_aPreviewMedia", {}))
+	var images: Array = _as_array(media.get("_aImages", []))
+	if not images.is_empty() and images[0] is Dictionary:
+		shot = images[0]
+		var media_file: String = str(shot.get(
+			"_sFile530", shot.get("_sFile220", shot.get("_sFile", ""))))
+		var media_base: String = str(shot.get("_sBaseUrl", "")).trim_suffix("/")
+		if not media_base.is_empty() and not media_file.is_empty():
+			return media_base + "/" + media_file
+	return ""
+
+
+static func _plain_text(value: String) -> String:
+	var out: String = value.replace("<br>", "\n").replace("<br/>", "\n").replace("<br />", "\n")
+	var tags: = RegEx.new()
+	if tags.compile("<[^>]*>") == OK: out = tags.sub(out, "", true)
+	return out.replace("&amp;", "&").replace("&quot;", "\"").replace("&#039;", "'").replace(
+		"&lt;", "<").replace("&gt;", ">").replace("&nbsp;", " ").strip_edges()
+
+
+static func _as_dictionary(value: Variant) -> Dictionary:
+	return value if value is Dictionary else {}
+
+
+static func _as_array(value: Variant) -> Array:
+	return value if value is Array else []

--- a/mod/net/lobby.gd
+++ b/mod/net/lobby.gd
@@ -163,6 +163,11 @@ func _build_support_footer() -> void:
 	discord.add_theme_color_override("font_color", DISCORD_COLOR)
 	discord.add_theme_color_override("font_hover_color", DISCORD_COLOR.lightened(0.3))
 	links.add_child(discord)
+	var community: = Button.new()
+	community.text = "Browse community packs"
+	community.tooltip_text = "Open the in-game GameBanana Dub Mode browser."
+	community.pressed.connect(Net.open_community_packs)
+	links.add_child(community)
 	links.add_child(_link_button("Support me on Ko-fi", KOFI_URL))
 	links.add_child(_link_button("Upvote on GameBanana", GAMEBANANA_URL))
 

--- a/mod/net/lobby.gd
+++ b/mod/net/lobby.gd
@@ -331,5 +331,7 @@ func _refresh() -> void:
 		var mismatched: PackedStringArray = Net.mismatched_players()
 		if mismatched.is_empty(): warning_label.text = ""
 		else:
-			warning_label.text = ("Your voice packs are not identical: %s.\nThis is only a problem "
-				+ "if the host picks clips from those packs. Start anyway if you like.") % "; ".join(mismatched)
+			warning_label.text = ("Your voice pack libraries are not identical: %s.\n"
+				+ "Standard mode only cares if the host picks clips from one of these packs. "
+				+ "For Dub Mode, a missing selected pack is okay: enable experimental pack sharing, "
+				+ "let everyone accept and verify it, then begin the dub.") % "; ".join(mismatched)

--- a/mod/net/net_manager.gd
+++ b/mod/net/net_manager.gd
@@ -1385,6 +1385,9 @@ const ENTRY_INSET: Vector2 = Vector2(24, 20)
 
 var _entry_layer: CanvasLayer
 var _entry_button: Button
+var _community_layer: CanvasLayer
+var _community_browser: Control
+var _extras_button: Button
 
 
 func _build_the_way_in() -> void:
@@ -1414,6 +1417,7 @@ func _build_the_way_in() -> void:
 
 func _place_entry_button() -> void:
 	if not is_instance_valid(_entry_button): return
+	_try_attach_extras_button()
 	_entry_button.visible = can_open_lobby()
 	if not _entry_button.visible: return
 	_entry_button.size = _entry_button.get_combined_minimum_size()
@@ -1442,6 +1446,69 @@ func open_lobby() -> void:
 	if not can_open_lobby(): return
 	log_net("opening the lobby")
 	M.world.CreateLobby()
+
+
+func open_community_packs() -> void:
+	if is_instance_valid(_community_browser): return
+	log_net("opening the community pack browser")
+	_community_layer = CanvasLayer.new()
+	_community_layer.layer = 192
+	add_child(_community_layer)
+	_community_browser = preload("res://net/community_pack_browser.gd").new()
+	_community_browser.closed.connect(_close_community_packs)
+	_community_layer.add_child(_community_browser)
+
+
+func _close_community_packs() -> void:
+	if is_instance_valid(_community_layer): _community_layer.queue_free()
+	_community_browser = null
+	_community_layer = null
+
+
+# The purchased game's source is intentionally not kept in this repository, so
+# there is no versioned Extras patch to anchor this button to yet. Both supported
+# builds do name the Extras scene, though. Insert into its largest direct button
+# container when it is present and fail closed if the layout is unfamiliar.
+# The lobby link below remains the reliable fallback until this has been checked
+# against retained 0.5.1 and 0.5.2 decompiles.
+func _try_attach_extras_button() -> void:
+	if is_instance_valid(_extras_button): return
+	if not get_tree().get_root().has_node("World"): return
+	var capsule: Node = M.world.primary_capsule
+	if capsule == null: return
+	var extras_root: Node
+	var stack: Array[Node] = []
+	for child: Node in capsule.get_children(): stack.append(child)
+	while not stack.is_empty():
+		var node: Node = stack.pop_back()
+		var clue: String = (node.scene_file_path + " " + node.name).to_lower()
+		if clue.contains("extra"):
+			extras_root = node
+			break
+		for child: Node in node.get_children(): stack.append(child)
+	if extras_root == null: return
+
+	var best: Container
+	var best_buttons: int = 1
+	stack.clear()
+	stack.append(extras_root)
+	while not stack.is_empty():
+		var node: Node = stack.pop_back()
+		if node is Container:
+			var count: int = 0
+			for child: Node in node.get_children():
+				if child is Button: count += 1
+			if count > best_buttons:
+				best = node
+				best_buttons = count
+		for child: Node in node.get_children(): stack.append(child)
+	if best == null: return
+	_extras_button = Button.new()
+	_extras_button.text = "COMMUNITY PACKS"
+	_extras_button.tooltip_text = "Browse and safely install community Dub Mode packs."
+	_extras_button.focus_mode = Control.FOCUS_NONE
+	_extras_button.pressed.connect(open_community_packs)
+	best.add_child(_extras_button)
 
 
 # on Net rather than world.gd: this is in the tree from startup, and _input runs

--- a/mod/net/net_manager.gd
+++ b/mod/net/net_manager.gd
@@ -16,10 +16,16 @@ signal scores_received(scores: PackedInt32Array)
 # anything that goes out, even when the protocol below does not move: two builds
 # that behave differently and both call themselves 1.1.5 make the one question
 # worth asking -- "what does yours say?" -- impossible to answer.
-const MOD_VERSION: String = "1.1.7"
+const MOD_VERSION: String = "1.2.0-dev"
 
 const PORT: int = 7654
 const MAX_PLAYERS: int = 4
+# 8: dub packs can be offered, streamed, verified and cached from the host. The
+# transfer calls live on a PackSync child so the handshake below stays pinned,
+# but _rpc_start_dub now carries a content ID and relative paths instead of the
+# host's absolute disk paths. It is deliberately incompatible with older builds.
+# 7: recording chunks are compressed and acknowledged instead of filling ENet's
+# reliable queue on a slow link.
 # 6: the dub watch goes through the host now, which took two new @rpc methods.
 # Both are named _rpc_* so the handshake still sorts first and a 1.1.6 joiner is
 # told what is wrong rather than hanging -- but every call index after them has
@@ -32,7 +38,7 @@ const MAX_PLAYERS: int = 4
 # 4: pack hashes cover the contents of a pack and not the folder name, so the
 # manifest from an older build would compare against nothing and read as a
 # missing pack. better to say so than to let it look broken.
-const PROTOCOL_VERSION: int = 6
+const PROTOCOL_VERSION: int = 8
 const CHUNK_SIZE: int = 24576
 const PERFORMANCE_TIMEOUT: float = 60.0
 const BARRIER_TIMEOUT: float = 90.0
@@ -77,6 +83,11 @@ var _barriers_done: Dictionary = {}
 # exactly like the new one.
 var session_id: int = 0
 
+# A child node keeps the large-file RPC list separate from Net's name-sorted RPC
+# list. It is created at startup on every peer, so its RPC path is always the
+# same: /root/Net/PackSync.
+var pack_sync: Node
+
 
 func is_online() -> bool: return mode != MODE.OFFLINE
 func is_host() -> bool: return mode == MODE.HOST
@@ -108,6 +119,7 @@ func player_name_for_slot(slot: int) -> String:
 
 
 func host_game(player_name: String, pack: String, port: int = PORT) -> Error:
+	if pack_sync != null: pack_sync.reset()
 	var peer: = ENetMultiplayerPeer.new()
 	var err: Error = peer.create_server(port, MAX_PLAYERS - 1)
 	if err != OK:
@@ -149,6 +161,7 @@ func _address_hint(address: String) -> String:
 
 
 func join_game(address: String, player_name: String, pack: String, port: int = PORT) -> Error:
+	if pack_sync != null: pack_sync.reset()
 	# before the socket, not after. this walks every voice pack on the disk, and
 	# once we are connected the only place left to do it is inside the multiplayer
 	# poll, where it stalls the handshake it is holding up.
@@ -182,6 +195,7 @@ func leave() -> void:
 	_pending_handshakes.clear()
 	_handshake_answered = false
 	_reset_session_state()
+	if pack_sync != null: pack_sync.reset()
 	player_list_changed.emit()
 
 
@@ -342,6 +356,7 @@ func _on_server_disconnected() -> void:
 	_pending_handshakes.clear()
 	_handshake_answered = false
 	_reset_session_state()
+	if pack_sync != null: pack_sync.reset()
 	server_disconnected.emit()
 	if get_tree().get_root().has_node("World"): M.world.CreateMenu()
 
@@ -992,21 +1007,26 @@ func await_end_round_choice() -> int:
 
 
 
-signal dub_should_start(folder: String, clip_paths: PackedStringArray)
+signal dub_should_start(pack_id: String, clip_paths: PackedStringArray)
 signal dub_begin
 signal dub_watch(playing: bool)
 
 
-func start_dub(folder: String, clip_paths: PackedStringArray) -> void:
+func prepare_dub_pack(folder: String, clip_paths: PackedStringArray) -> Dictionary:
+	if pack_sync == null: return {}
+	return await pack_sync.prepare_dub(folder, clip_paths)
+
+
+func start_dub(pack_id: String, clip_paths: PackedStringArray) -> void:
 	if not is_host(): return
 	begin_session()
-	log_net("starting dub '%s' with %d clips" % [folder, clip_paths.size()])
-	_rpc_start_dub.rpc(session_id, folder, clip_paths)
+	log_net("starting dub pack %s with %d clips" % [pack_id.left(12), clip_paths.size()])
+	_rpc_start_dub.rpc(session_id, pack_id, clip_paths)
 
 @rpc("authority", "call_remote", "reliable")
-func _rpc_start_dub(sid: int, folder: String, clip_paths: PackedStringArray) -> void:
+func _rpc_start_dub(sid: int, pack_id: String, clip_paths: PackedStringArray) -> void:
 	begin_session(sid)
-	dub_should_start.emit(folder, clip_paths)
+	dub_should_start.emit(pack_id, clip_paths)
 
 
 var _dub_begin_pending: bool = false
@@ -1265,12 +1285,17 @@ func resolve_dub_owners(clip_characters: Array) -> PackedInt32Array:
 	return owners
 
 
-func _on_dub_should_start(folder: String, clip_paths: PackedStringArray) -> void:
+func _on_dub_should_start(pack_id: String, relative_clip_paths: PackedStringArray) -> void:
 	if is_host(): return
 	_loading_hint("The host has started. Loading the dub pack...")
-	var remap: Dictionary = pack_remap(_host_manifest())
-	folder = localise_path(folder, remap)
-	clip_paths = localise_paths(clip_paths, remap)
+	var folder: String = pack_sync.local_path_for(pack_id) if pack_sync != null else ""
+	var clip_paths: PackedStringArray = (
+		pack_sync.local_clip_paths(pack_id, relative_clip_paths) if pack_sync != null
+		else PackedStringArray())
+	if folder.is_empty() or clip_paths.size() != relative_clip_paths.size():
+		_abort_to_menu("Cannot start: the synchronized dub pack is not ready on this computer.")
+		return
+	pack_sync.dismiss_for_start(pack_id)
 	# a dub pack drags the video in with it, so this is the slowest load in the
 	# mod by far. the host already does it on a thread in clip_selection_dub;
 	# doing it inline here froze the joiner until the host's ENet gave up on it.
@@ -1433,6 +1458,10 @@ func _input(event: InputEvent) -> void:
 
 
 func _ready() -> void:
+	pack_sync = preload("res://net/pack_sync.gd").new()
+	pack_sync.name = "PackSync"
+	add_child(pack_sync)
+	pack_sync.configure(self)
 	# CONNECT_DEFERRED for the same reason the lobby uses it: these fire from
 	# inside the multiplayer poll. Loading a pack and swapping the scene from in
 	# there is what stranded joiners on the lobby screen while the host played on.

--- a/mod/net/net_manager.gd
+++ b/mod/net/net_manager.gd
@@ -87,6 +87,7 @@ var session_id: int = 0
 # list. It is created at startup on every peer, so its RPC path is always the
 # same: /root/Net/PackSync.
 var pack_sync: Node
+var community_pack_downloads: Node
 
 
 func is_online() -> bool: return mode != MODE.OFFLINE
@@ -1385,6 +1386,7 @@ const ENTRY_INSET: Vector2 = Vector2(24, 20)
 
 var _entry_layer: CanvasLayer
 var _entry_button: Button
+var _community_entry_button: Button
 var _community_layer: CanvasLayer
 var _community_browser: Control
 var _extras_button: Button
@@ -1404,6 +1406,13 @@ func _build_the_way_in() -> void:
 	_entry_button.focus_mode = Control.FOCUS_NONE
 	_entry_button.pressed.connect(open_lobby)
 	_entry_layer.add_child(_entry_button)
+	_community_entry_button = Button.new()
+	_community_entry_button.text = "COMMUNITY PACKS"
+	_community_entry_button.tooltip_text = (
+		"Browse and install GameBanana Dub Mode packs. Downloads continue in the background.")
+	_community_entry_button.focus_mode = Control.FOCUS_NONE
+	_community_entry_button.pressed.connect(open_community_packs)
+	_entry_layer.add_child(_community_entry_button)
 
 	# polled: there is no hook into the game's screen changes, and they all go
 	# through primary_capsule anyway.
@@ -1419,11 +1428,19 @@ func _place_entry_button() -> void:
 	if not is_instance_valid(_entry_button): return
 	_try_attach_extras_button()
 	_entry_button.visible = can_open_lobby()
+	_community_entry_button.visible = _entry_button.visible
 	if not _entry_button.visible: return
 	_entry_button.size = _entry_button.get_combined_minimum_size()
 	var view: Vector2 = _entry_layer.get_viewport().get_visible_rect().size
 	_entry_button.position = Vector2(
 		view.x - _entry_button.size.x - ENTRY_INSET.x, ENTRY_INSET.y)
+	var queued: int = community_pack_downloads.active_count()
+	_community_entry_button.text = (
+		"COMMUNITY PACKS  (%d)" % queued if queued > 0 else "COMMUNITY PACKS")
+	_community_entry_button.size = _community_entry_button.get_combined_minimum_size()
+	_community_entry_button.position = Vector2(
+		view.x - _community_entry_button.size.x - ENTRY_INSET.x,
+		_entry_button.position.y + _entry_button.size.y + 8)
 
 
 # menus only. CreateLobby frees everything under primary_capsule, so F9 mid-show
@@ -1463,6 +1480,12 @@ func _close_community_packs() -> void:
 	if is_instance_valid(_community_layer): _community_layer.queue_free()
 	_community_browser = null
 	_community_layer = null
+
+
+func community_pack_library_changed() -> void:
+	_manifest_cache.clear()
+	if is_online(): manifests[my_id()] = voice_pack_manifest()
+	_place_entry_button.call_deferred()
 
 
 # The purchased game's source is intentionally not kept in this repository, so
@@ -1525,6 +1548,10 @@ func _input(event: InputEvent) -> void:
 
 
 func _ready() -> void:
+	community_pack_downloads = preload("res://net/community_pack_queue.gd").new()
+	community_pack_downloads.name = "CommunityPackDownloads"
+	add_child(community_pack_downloads)
+	community_pack_downloads.configure(self)
 	pack_sync = preload("res://net/pack_sync.gd").new()
 	pack_sync.name = "PackSync"
 	add_child(pack_sync)

--- a/mod/net/pack_sync.gd
+++ b/mod/net/pack_sync.gd
@@ -1126,6 +1126,10 @@ func _render_deferred() -> void:
 	_render()
 
 
+func _development_controls_enabled() -> bool:
+	return _net != null and str(_net.MOD_VERSION).contains("-dev")
+
+
 func _render() -> void:
 	if not is_instance_valid(_panel) or _active_offer.is_empty(): return
 	if _panel_dismissed:
@@ -1159,7 +1163,8 @@ func _render() -> void:
 					status += " — " + str(record["error"])
 				lines.append("%s: %s" % [_net.player_name_for_slot(slot), status])
 			_roster.text = "\n".join(lines)
-		_force_download_box.visible = not _host_sharing_confirmed
+		_force_download_box.visible = (
+			not _host_sharing_confirmed and _development_controls_enabled())
 		_progress.visible = false
 		_primary.visible = true
 		_primary.text = "Begin dub" if _host_sharing_confirmed else "Enable experimental sharing"
@@ -1233,7 +1238,8 @@ func _begin_host_sharing() -> void:
 	if (_net == null or not _net.is_host() or _active_offer.is_empty()
 		or _host_sharing_confirmed): return
 	_active_offer["force_download"] = _test_force_download or (
-		is_instance_valid(_force_download_box) and _force_download_box.button_pressed)
+		_development_controls_enabled() and is_instance_valid(_force_download_box)
+		and _force_download_box.button_pressed)
 	_host_sharing_confirmed = true
 	for peer: int in _net.players:
 		if peer != 1: _send_offer_manifest.call_deferred(peer, str(_active_offer["id"]))

--- a/mod/net/pack_sync.gd
+++ b/mod/net/pack_sync.gd
@@ -58,12 +58,16 @@ var _download_file: FileAccess
 var _download_index: int = -1
 var _download_offset: int = 0
 var _render_queued: bool = false
+var _panel_dismissed: bool = true
+var _force_fresh_pending: bool = false
 
 var _layer: CanvasLayer
 var _panel: PanelContainer
 var _title: Label
 var _detail: Label
+var _warning: Label
 var _roster: Label
+var _force_download_box: CheckBox
 var _progress: ProgressBar
 var _primary: Button
 var _secondary: Button
@@ -72,6 +76,7 @@ var _secondary: Button
 # client and host to press the visible buttons.
 var _test_auto_accept: bool = false
 var _test_auto_begin: bool = false
+var _test_force_download: bool = false
 
 
 func configure(net: Node) -> void:
@@ -80,9 +85,10 @@ func configure(net: Node) -> void:
 		_net.player_list_changed.connect(_on_roster_changed, CONNECT_DEFERRED)
 
 
-func enable_test_automation(auto_accept: bool, auto_begin: bool) -> void:
+func enable_test_automation(auto_accept: bool, auto_begin: bool, force_download: bool = false) -> void:
 	_test_auto_accept = auto_accept
 	_test_auto_begin = auto_begin
+	_test_force_download = force_download
 
 
 func set_test_cache_root(path: String) -> void:
@@ -112,13 +118,14 @@ func reset() -> void:
 	_client_error = ""
 	_client_received = 0
 	_client_transfer_id = 0
+	_force_fresh_pending = false
+	_panel_dismissed = true
 	_hide_panel.call_deferred()
 	_emit_state_changed.call_deferred()
 
 
 func dismiss_for_start(pack_id: String) -> void:
-	if str(_active_offer.get("pack_id", "")) == pack_id and is_instance_valid(_panel):
-		_panel.visible = false
+	if str(_active_offer.get("pack_id", "")) == pack_id: _dismiss_panel()
 
 
 func local_path_for(pack_id: String) -> String:
@@ -148,6 +155,7 @@ func prepare_dub(folder: String, clip_paths: PackedStringArray) -> Dictionary:
 	_host_decision = 0
 	_host_sharing_confirmed = false
 	_client_error = ""
+	_panel_dismissed = false
 	_show_scanning()
 
 	var thread: = Thread.new()
@@ -219,7 +227,7 @@ func prepare_dub(folder: String, clip_paths: PackedStringArray) -> Dictionary:
 		"pack_id": pack_id,
 		"clip_paths": relative_clips,
 	}
-	if is_instance_valid(_panel): _panel.visible = false
+	_dismiss_panel()
 	return result
 
 
@@ -373,6 +381,9 @@ func _valid_sha256(value: String) -> bool:
 func _rpc_pack_offer_begin(summary: Dictionary) -> void:
 	if _net == null or _net.is_host(): return
 	var offer_id: String = str(summary.get("id", ""))
+	if str(_active_offer.get("id", "")) == offer_id: return
+	_panel_dismissed = false
+	_force_fresh_pending = false
 	var pack_id: String = str(summary.get("pack_id", ""))
 	var pack_name: String = str(summary.get("name", "Dub pack"))
 	var folder_name: String = str(summary.get("folder_name", ""))
@@ -384,7 +395,6 @@ func _rpc_pack_offer_begin(summary: Dictionary) -> void:
 		_active_offer = {"id": offer_id, "pack_id": pack_id, "total_bytes": maxi(0, total)}
 		_client_fail("The host sent an invalid pack summary.")
 		return
-	if str(_active_offer.get("id", "")) == offer_id: return
 	_close_download_file()
 	_incoming_offer = {
 		"id": offer_id,
@@ -394,6 +404,7 @@ func _rpc_pack_offer_begin(summary: Dictionary) -> void:
 		"total_bytes": total,
 		"file_count": count,
 		"ignored": clampi(int(summary.get("ignored", 0)), 0, MAX_FILES),
+		"force_download": summary.get("force_download", false) == true,
 	}
 	_incoming_files = []
 	_incoming_page = 0
@@ -402,6 +413,8 @@ func _rpc_pack_offer_begin(summary: Dictionary) -> void:
 	_client_state = "checking"
 	_client_error = ""
 	_client_received = 0
+	_force_fresh_pending = false
+	_panel_dismissed = false
 	_queue_render()
 	_send_client_state("checking")
 
@@ -457,6 +470,7 @@ func _rpc_pack_offer_end(offer_id: String, clips: Array) -> void:
 		_reject_incoming_offer(problem)
 		return
 	_active_offer = offer
+	_force_fresh_pending = bool(offer.get("force_download", false))
 	_incoming_offer.clear()
 	_incoming_files.clear()
 	_incoming_page = 0
@@ -477,6 +491,7 @@ func _send_offer_manifest(peer: int, offer_id: String) -> void:
 		"total_bytes": _active_offer["total_bytes"],
 		"file_count": files.size(),
 		"ignored": _active_offer.get("ignored", 0),
+		"force_download": _active_offer.get("force_download", false),
 	}
 	_rpc_pack_offer_begin.rpc_id(peer, summary)
 	var pages: int = int((files.size() + MANIFEST_FILES_PER_PAGE - 1) / MANIFEST_FILES_PER_PAGE)
@@ -493,6 +508,12 @@ func _send_offer_manifest(peer: int, offer_id: String) -> void:
 
 func _check_for_existing_pack(offer_id: String) -> void:
 	if str(_active_offer.get("id", "")) != offer_id: return
+	if bool(_active_offer.get("force_download", false)):
+		_client_state = "offered"
+		_queue_render()
+		_send_client_state("offered")
+		if _test_auto_accept: accept_download.call_deferred()
+		return
 	var candidates: PackedStringArray = []
 	var pack_id: String = str(_active_offer["pack_id"])
 	var cached: String = _cache_path(pack_id)
@@ -569,12 +590,14 @@ func accept_download() -> void:
 		_client_fail("Could not create the multiplayer pack cache.")
 		return
 
+	var force_fresh: bool = bool(_active_offer.get("force_download", false)) and _force_fresh_pending
 	var offsets: Array[int] = []
 	var present: int = 0
 	for value_item: Variant in Array(_active_offer["files"]):
 		var item: Dictionary = value_item
 		var target: String = _cache_path(pack_id).path_join(str(item["path"]))
-		var size: int = _file_size(target) if FileAccess.file_exists(target) else 0
+		var size: int = 0 if force_fresh else (
+			_file_size(target) if FileAccess.file_exists(target) else 0)
 		if size < 0 or size > int(item["size"]):
 			var reset_file: FileAccess = FileAccess.open(target, FileAccess.WRITE)
 			if reset_file != null: reset_file.close()
@@ -589,6 +612,18 @@ func accept_download() -> void:
 		if free > 0 and free < needed + FREE_SPACE_MARGIN:
 			_client_fail("Not enough disk space: this download still needs %s." % _format_bytes(needed))
 			return
+
+	if force_fresh:
+		for value_item: Variant in Array(_active_offer["files"]):
+			var item: Dictionary = value_item
+			var target: String = _cache_path(pack_id).path_join(str(item["path"]))
+			if not FileAccess.file_exists(target): continue
+			var reset_file: FileAccess = FileAccess.open(target, FileAccess.WRITE)
+			if reset_file == null:
+				_client_fail("Could not reset the cached copy of %s for the test download." % str(item["path"]))
+				return
+			reset_file.close()
+		_force_fresh_pending = false
 
 	_client_state = "downloading"
 	_client_error = ""
@@ -892,6 +927,7 @@ func _rpc_pack_cancel(offer_id: String, reason: String) -> void:
 	_incoming_offer.clear()
 	_incoming_files.clear()
 	_incoming_manifest_chars = 0
+	_panel_dismissed = true
 	_hide_panel.call_deferred()
 	_emit_state_changed.call_deferred()
 
@@ -972,6 +1008,11 @@ func _hide_panel() -> void:
 	if is_instance_valid(_panel): _panel.visible = false
 
 
+func _dismiss_panel() -> void:
+	_panel_dismissed = true
+	_hide_panel()
+
+
 func _emit_state_changed() -> void:
 	state_changed.emit()
 
@@ -1007,9 +1048,20 @@ func _build_ui() -> void:
 	_detail.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
 	column.add_child(_detail)
 
+	_warning = Label.new()
+	_warning.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
+	_warning.add_theme_color_override("font_color", Color("ffcc44"))
+	column.add_child(_warning)
+
 	_roster = Label.new()
 	_roster.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
 	column.add_child(_roster)
+
+	_force_download_box = CheckBox.new()
+	_force_download_box.text = "Force fresh download for testing"
+	_force_download_box.tooltip_text = ("Ignore installed and cached copies for this offer. "
+		+ "Clients must still accept the download.")
+	column.add_child(_force_download_box)
 
 	_progress = ProgressBar.new()
 	_progress.show_percentage = true
@@ -1029,12 +1081,16 @@ func _build_ui() -> void:
 
 
 func _show_scanning() -> void:
+	_panel_dismissed = false
 	_panel.visible = true
-	_title.text = "EXPERIMENTAL DUB PACK SHARING"
-	_detail.text = ("Preparing the selected pack. Sharing is experimental: large transfers may be slow "
-		+ "or cause disconnects on weaker connections. Only use it when everyone trusts the host and "
-		+ "the source of the pack. Nothing will be offered until you confirm.")
+	_title.text = "DUB PACK SHARING"
+	_detail.text = "Checking the selected pack and calculating its content hash..."
+	_warning.visible = true
+	_warning.text = ("EXPERIMENTAL: Large transfers may be slow or disconnect weaker connections. "
+		+ "Only share packs from sources you trust.")
 	_roster.text = ""
+	_force_download_box.button_pressed = false
+	_force_download_box.visible = false
 	_progress.visible = false
 	_primary.visible = false
 	_secondary.visible = true
@@ -1044,10 +1100,13 @@ func _show_scanning() -> void:
 
 func _show_host_error(reason: String) -> void:
 	_host_decision = -1
+	_panel_dismissed = false
 	_panel.visible = true
 	_title.text = "PACK CANNOT BE SHARED"
 	_detail.text = reason
+	_warning.visible = false
 	_roster.text = ""
+	_force_download_box.visible = false
 	_progress.visible = false
 	_primary.visible = false
 	_secondary.visible = true
@@ -1069,14 +1128,17 @@ func _render_deferred() -> void:
 
 func _render() -> void:
 	if not is_instance_valid(_panel) or _active_offer.is_empty(): return
+	if _panel_dismissed:
+		_panel.visible = false
+		return
 	_panel.visible = true
 	var total: int = int(_active_offer.get("total_bytes", 0))
 	if _net != null and _net.is_host():
-		_title.text = "EXPERIMENTAL DUB PACK SHARING"
-		_detail.text = ("%s — %s. Host-to-player pack sharing is experimental. Large transfers may "
-			+ "be slow or cause disconnects on weaker connections. Only use it when everyone trusts "
-			+ "the host and the source of this pack.") % [
-			_active_offer.get("name", "Dub pack"), _format_bytes(total)]
+		_title.text = "DUB PACK SHARING"
+		_detail.text = "%s — %s" % [_active_offer.get("name", "Dub pack"), _format_bytes(total)]
+		_warning.visible = true
+		_warning.text = ("EXPERIMENTAL: Large transfers may be slow or disconnect weaker connections. "
+			+ "Only share packs from sources you trust.")
 		var ignored: int = int(_active_offer.get("ignored", 0))
 		if ignored > 0:
 			_detail.text += " %d generated or unsupported file(s) will not be copied." % ignored
@@ -1097,6 +1159,7 @@ func _render() -> void:
 					status += " — " + str(record["error"])
 				lines.append("%s: %s" % [_net.player_name_for_slot(slot), status])
 			_roster.text = "\n".join(lines)
+		_force_download_box.visible = not _host_sharing_confirmed
 		_progress.visible = false
 		_primary.visible = true
 		_primary.text = "Begin dub" if _host_sharing_confirmed else "Enable experimental sharing"
@@ -1105,11 +1168,13 @@ func _render() -> void:
 		_secondary.text = "Cancel"
 		_secondary.disabled = false
 	else:
-		_title.text = "EXPERIMENTAL PACK DOWNLOAD"
-		_detail.text = ("%s — %s. Host-to-player sharing is experimental and may be slow or "
-			+ "disconnect on unstable connections. Only download packs from a host you trust.") % [
-			_active_offer.get("name", "Dub pack"), _format_bytes(total)]
+		_title.text = "DUB PACK DOWNLOAD"
+		_detail.text = "%s — %s" % [_active_offer.get("name", "Dub pack"), _format_bytes(total)]
+		_warning.visible = true
+		_warning.text = ("EXPERIMENTAL: Transfers may be slow or disconnect unstable connections. "
+			+ "Only download packs from a host you trust.")
 		_roster.text = _client_status_text()
+		_force_download_box.visible = false
 		_progress.visible = _client_state in ["downloading", "verifying", "ready"]
 		_progress.min_value = 0
 		_progress.max_value = maxi(1, total)
@@ -1126,7 +1191,11 @@ func _render() -> void:
 func _client_status_text() -> String:
 	match _client_state:
 		"checking": return "Checking whether this pack is already installed..."
-		"offered": return "This pack is missing. It will be kept in the multiplayer cache, not installed into your pack library."
+		"offered":
+			if bool(_active_offer.get("force_download", false)):
+				return ("The host requested a fresh test transfer, so installed and cached copies will be "
+					+ "ignored. The download stays in the multiplayer cache.")
+			return "This pack is missing. It will be kept in the multiplayer cache, not installed into your pack library."
 		"declined": return "Download declined. You can change your mind while the host is still waiting."
 		"downloading": return "Downloading from the host: %s / %s" % [
 			_format_bytes(_client_received),
@@ -1153,7 +1222,9 @@ func _state_label(state: String) -> String:
 func _on_primary() -> void:
 	if _net != null and _net.is_host():
 		if not _host_sharing_confirmed: _begin_host_sharing()
-		elif _all_players_ready(): _host_decision = 1
+		elif _all_players_ready():
+			_host_decision = 1
+			_dismiss_panel()
 	else:
 		accept_download()
 
@@ -1161,6 +1232,8 @@ func _on_primary() -> void:
 func _begin_host_sharing() -> void:
 	if (_net == null or not _net.is_host() or _active_offer.is_empty()
 		or _host_sharing_confirmed): return
+	_active_offer["force_download"] = _test_force_download or (
+		is_instance_valid(_force_download_box) and _force_download_box.button_pressed)
 	_host_sharing_confirmed = true
 	for peer: int in _net.players:
 		if peer != 1: _send_offer_manifest.call_deferred(peer, str(_active_offer["id"]))
@@ -1169,11 +1242,8 @@ func _begin_host_sharing() -> void:
 
 func _on_secondary() -> void:
 	if _net != null and _net.is_host():
-		if _active_offer.is_empty():
-			_host_decision = -1
-			_panel.visible = false
-		else:
-			_host_decision = -1
+		_dismiss_panel()
+		_host_decision = -1
 	else:
 		decline_download()
 

--- a/mod/net/pack_sync.gd
+++ b/mod/net/pack_sync.gd
@@ -1,0 +1,1164 @@
+extends Node
+# Host-to-client dub-pack transfer. This is a child of the Net autoload instead
+# of more code on Net itself: Godot numbers RPCs by their sorted name within a
+# node, and keeping this protocol on /root/Net/PackSync means it cannot move the
+# join handshake that has to survive old builds.
+
+signal pack_ready(pack_id: String, local_path: String)
+signal state_changed
+
+const CACHE_ROOT: String = "user://multiplayer_pack_cache"
+const COMPLETE_MARKER: String = ".net-pack-complete"
+
+const CHUNK_SIZE: int = 24576
+const SEND_WINDOW: int = 98304
+const STALL_TIMEOUT_MSEC: int = 45000
+const FREE_SPACE_MARGIN: int = 64 * 1024 * 1024
+
+const MAX_FILES: int = 2048
+const MAX_PACK_BYTES: int = 4 * 1024 * 1024 * 1024
+const MAX_FILE_BYTES: int = 2 * 1024 * 1024 * 1024
+const MAX_PATH_LENGTH: int = 512
+const MAX_MANIFEST_TEXT: int = 2 * 1024 * 1024
+const MANIFEST_FILES_PER_PAGE: int = 32
+
+# These are all inert data formats the base game's external pack loader may
+# consume. Never accept scripts, libraries, executables, archives or PCKs from a
+# peer. Unknown files are left behind on the host rather than copied blindly.
+const SAFE_EXTENSIONS: PackedStringArray = [
+	"wav", "mp3", "ogg", "ogv",
+	"ini", "cfg", "json", "txt", "md",
+	"png", "jpg", "jpeg", "webp", "bmp", "tga", "svg", "dds", "exr", "hdr",
+]
+const AUDIO_EXTENSIONS: PackedStringArray = ["wav", "mp3", "ogg"]
+
+var _net: Node
+var _cache_root: String = CACHE_ROOT
+
+var _active_offer: Dictionary = {}
+var _incoming_offer: Dictionary = {}
+var _incoming_files: Array = []
+var _incoming_page: int = 0
+var _incoming_manifest_chars: int = 0
+var _host_folder: String = ""
+var _pack_paths: Dictionary = {}
+var _peer_states: Dictionary = {}
+var _host_acks: Dictionary = {}
+var _transfer_tokens: Dictionary = {}
+var _offer_serial: int = 0
+var _prepare_generation: int = 0
+var _host_decision: int = 0
+
+var _client_state: String = "idle"
+var _client_error: String = ""
+var _client_received: int = 0
+var _client_transfer_id: int = 0
+var _download_file: FileAccess
+var _download_index: int = -1
+var _download_offset: int = 0
+var _render_queued: bool = false
+
+var _layer: CanvasLayer
+var _panel: PanelContainer
+var _title: Label
+var _detail: Label
+var _roster: Label
+var _progress: ProgressBar
+var _primary: Button
+var _secondary: Button
+
+# Used only by the headless network smoke test. Production always requires the
+# client and host to press the visible buttons.
+var _test_auto_accept: bool = false
+var _test_auto_begin: bool = false
+
+
+func configure(net: Node) -> void:
+	_net = net
+	if not _net.player_list_changed.is_connected(_on_roster_changed):
+		_net.player_list_changed.connect(_on_roster_changed, CONNECT_DEFERRED)
+
+
+func enable_test_automation(auto_accept: bool, auto_begin: bool) -> void:
+	_test_auto_accept = auto_accept
+	_test_auto_begin = auto_begin
+
+
+func set_test_cache_root(path: String) -> void:
+	if OS.is_debug_build() and path.begins_with("user://"):
+		_cache_root = path.trim_suffix("/")
+
+
+func _ready() -> void:
+	_build_ui()
+
+
+func reset() -> void:
+	_prepare_generation += 1
+	_close_download_file()
+	_active_offer.clear()
+	_incoming_offer.clear()
+	_incoming_files.clear()
+	_incoming_page = 0
+	_incoming_manifest_chars = 0
+	_host_folder = ""
+	_peer_states.clear()
+	_host_acks.clear()
+	_transfer_tokens.clear()
+	_host_decision = -1
+	_client_state = "idle"
+	_client_error = ""
+	_client_received = 0
+	_client_transfer_id = 0
+	_hide_panel.call_deferred()
+	_emit_state_changed.call_deferred()
+
+
+func dismiss_for_start(pack_id: String) -> void:
+	if str(_active_offer.get("pack_id", "")) == pack_id and is_instance_valid(_panel):
+		_panel.visible = false
+
+
+func local_path_for(pack_id: String) -> String:
+	return str(_pack_paths.get(pack_id, ""))
+
+
+func local_clip_paths(pack_id: String, relative_paths: PackedStringArray) -> PackedStringArray:
+	var root: String = local_path_for(pack_id).replace("\\", "/").trim_suffix("/")
+	if root.is_empty(): return PackedStringArray()
+	var out: PackedStringArray = []
+	for relative: String in relative_paths:
+		if not _safe_relative_path(relative) or not AUDIO_EXTENSIONS.has(relative.get_extension().to_lower()):
+			return PackedStringArray()
+		var full: String = root.path_join(relative).replace("\\", "/").simplify_path()
+		if not full.begins_with(root + "/"): return PackedStringArray()
+		out.append(full)
+	return out
+
+
+func prepare_dub(folder: String, clip_paths: PackedStringArray) -> Dictionary:
+	if _net == null or not _net.is_host() or not _net.is_online(): return {}
+	if not _active_offer.is_empty(): _cancel_host_offer("The host chose another dub pack.")
+	_prepare_generation += 1
+	var generation: int = _prepare_generation
+
+	_host_folder = folder.trim_suffix("/").replace("\\", "/")
+	_host_decision = 0
+	_client_error = ""
+	_show_scanning()
+
+	var thread: = Thread.new()
+	var start_error: Error = thread.start(_build_manifest.bind(_host_folder))
+	if start_error != OK:
+		_show_host_error("Could not start the pack scan (error %d)." % start_error)
+		return {}
+	var abandoned: bool = false
+	while thread.is_alive():
+		if generation != _prepare_generation or not _net.is_online() or not _net.is_host():
+			abandoned = true
+		await get_tree().process_frame
+	var built: Dictionary = thread.wait_to_finish()
+	if abandoned or generation != _prepare_generation: return {}
+	if _host_decision < 0:
+		reset()
+		return {}
+	if built.has("error"):
+		_show_host_error(str(built["error"]))
+		return {}
+
+	var relative_clips: PackedStringArray = []
+	var known_paths: Dictionary = {}
+	for item: Dictionary in built.get("files", []): known_paths[str(item["path"])] = true
+	for path: String in clip_paths:
+		var relative: String = _relative_path(_host_folder, path)
+		if relative.is_empty() or not known_paths.has(relative):
+			_show_host_error("The selected clip is outside the pack or was not safe to transfer: %s" % path.get_file())
+			return {}
+		relative_clips.append(relative)
+
+	_offer_serial += 1
+	var pack_id: String = str(built["pack_id"])
+	_active_offer = {
+		"id": "%s:%d:%d" % [pack_id, Time.get_ticks_msec(), _offer_serial],
+		"pack_id": pack_id,
+		"name": _host_folder.get_file(),
+		"folder_name": _host_folder.get_file(),
+		"total_bytes": int(built["total_bytes"]),
+		"files": built["files"],
+		"clips": Array(relative_clips),
+		"ignored": int(built.get("ignored", 0)),
+	}
+	_pack_paths[pack_id] = _host_folder
+	_peer_states.clear()
+	_peer_states[1] = _state_record("ready", int(built["total_bytes"]), "")
+	for peer: int in _net.players:
+		if peer != 1: _peer_states[peer] = _state_record("checking", 0, "")
+
+	_net.log_net("offering dub pack '%s' (%s, %d files)" % [
+		_active_offer["name"], _format_bytes(int(_active_offer["total_bytes"])),
+		Array(_active_offer["files"]).size()])
+	for peer: int in _net.players:
+		if peer != 1: _send_offer_manifest.call_deferred(peer, str(_active_offer["id"]))
+	_queue_render()
+
+	while _host_decision == 0:
+		if generation != _prepare_generation: return {}
+		if not _net.is_online() or not _net.is_host():
+			reset()
+			return {}
+		if _test_auto_begin and _all_players_ready(): _host_decision = 1
+		await get_tree().process_frame
+
+	if _host_decision < 0:
+		if not _active_offer.is_empty(): _cancel_host_offer("The host canceled this dub pack.")
+		return {}
+
+	var result: Dictionary = {
+		"pack_id": pack_id,
+		"clip_paths": relative_clips,
+	}
+	if is_instance_valid(_panel): _panel.visible = false
+	return result
+
+
+func _build_manifest(root: String) -> Dictionary:
+	if not DirAccess.dir_exists_absolute(root): return {"error": "The selected dub-pack folder no longer exists."}
+	var files: Array[Dictionary] = []
+	var stack: Array[String] = [root]
+	var ignored: int = 0
+	var total: int = 0
+
+	while not stack.is_empty():
+		var current: String = stack.pop_back()
+		var dir: DirAccess = DirAccess.open(current)
+		if dir == null: return {"error": "Could not read the dub-pack folder: %s" % current}
+		dir.list_dir_begin()
+		var name: String = dir.get_next()
+		while not name.is_empty():
+			if name == "." or name == "..":
+				name = dir.get_next()
+				continue
+			if dir.is_link(name):
+				ignored += 1
+				name = dir.get_next()
+				continue
+			var full: String = current.path_join(name).replace("\\", "/")
+			if dir.current_is_dir():
+				stack.append(full)
+			else:
+				var relative: String = _relative_path(root, full)
+				if not _host_file_is_safe(relative):
+					ignored += 1
+					name = dir.get_next()
+					continue
+				var size: int = _file_size(full)
+				if size < 0: return {"error": "Could not read %s." % relative}
+				if size > MAX_FILE_BYTES: return {"error": "%s is larger than the %s per-file limit." % [relative, _format_bytes(MAX_FILE_BYTES)]}
+				total += size
+				if total > MAX_PACK_BYTES: return {"error": "This pack is larger than the %s transfer limit." % _format_bytes(MAX_PACK_BYTES)}
+				var sha: String = FileAccess.get_sha256(full)
+				if sha.is_empty(): return {"error": "Could not checksum %s." % relative}
+				files.append({"path": relative, "size": size, "sha256": sha})
+				if files.size() > MAX_FILES: return {"error": "This pack contains more than %d transferable files." % MAX_FILES}
+			name = dir.get_next()
+		dir.list_dir_end()
+
+	files.sort_custom(func(a: Dictionary, b: Dictionary) -> bool: return str(a["path"]) < str(b["path"]))
+	var has_video: bool = false
+	var canonical: String = ""
+	for item: Dictionary in files:
+		if str(item["path"]).to_lower() == "dub_video.ogv": has_video = true
+		canonical += "%d:%s:%d:%s\n" % [
+			str(item["path"]).length(), item["path"], item["size"], item["sha256"]]
+	if not has_video: return {"error": "The selected folder has no root-level dub_video.ogv."}
+	if files.is_empty(): return {"error": "The selected dub pack contains no transferable files."}
+	if canonical.length() > MAX_MANIFEST_TEXT: return {"error": "The pack manifest is too large to send safely."}
+	return {
+		"pack_id": canonical.sha256_text(),
+		"files": files,
+		"total_bytes": total,
+		"ignored": ignored,
+	}
+
+
+func _host_file_is_safe(relative: String) -> bool:
+	if not _safe_relative_path(relative): return false
+	var file_name: String = relative.get_file()
+	var extension: String = file_name.get_extension().to_lower()
+	if not SAFE_EXTENSIONS.has(extension): return false
+	# The base game creates underscore-prefixed recordings of its own. They are
+	# output, not pack input. The backing track is the intentional exception.
+	if AUDIO_EXTENSIONS.has(extension) and file_name.begins_with("_"):
+		return file_name.get_basename().to_lower() == "_backing_track"
+	return true
+
+
+func _safe_relative_path(path: String) -> bool:
+	if path.is_empty() or path.length() > MAX_PATH_LENGTH: return false
+	if path.contains("\\") or path.contains(":") or path.begins_with("/"): return false
+	if path.contains("\n") or path.contains("\r") or path.contains("\t"): return false
+	if path != path.simplify_path(): return false
+	for part: String in path.split("/"):
+		if part.is_empty() or part == "." or part == "..": return false
+	return true
+
+
+func _relative_path(root: String, full_path: String) -> String:
+	var clean_root: String = root.replace("\\", "/").trim_suffix("/").simplify_path()
+	var clean_full: String = full_path.replace("\\", "/").simplify_path()
+	var prefix: String = clean_root + "/"
+	if not clean_full.begins_with(prefix): return ""
+	var relative: String = clean_full.substr(prefix.length())
+	return relative if _safe_relative_path(relative) else ""
+
+
+func _valid_offer(value: Variant) -> String:
+	if not (value is Dictionary): return "The host sent an invalid pack offer."
+	var offer: Dictionary = value
+	var offer_id: String = str(offer.get("id", ""))
+	var pack_id: String = str(offer.get("pack_id", ""))
+	if offer_id.is_empty() or offer_id.length() > 160: return "The pack offer has an invalid ID."
+	if not _valid_sha256(pack_id): return "The pack offer has an invalid content hash."
+	var files_value: Variant = offer.get("files", null)
+	if not (files_value is Array): return "The pack offer has no valid file manifest."
+	var files: Array = files_value
+	if files.is_empty() or files.size() > MAX_FILES: return "The pack offer contains an invalid number of files."
+
+	var paths: Dictionary = {}
+	var total: int = 0
+	var has_video: bool = false
+	var canonical: String = ""
+	for value_item: Variant in files:
+		if not (value_item is Dictionary): return "The pack offer contains an invalid file entry."
+		var item: Dictionary = value_item
+		var path: String = str(item.get("path", ""))
+		var size: int = int(item.get("size", -1))
+		var sha: String = str(item.get("sha256", ""))
+		if not _safe_relative_path(path): return "The pack offer contains an unsafe path."
+		if paths.has(path): return "The pack offer contains the same path twice."
+		if not SAFE_EXTENSIONS.has(path.get_extension().to_lower()): return "The pack offer contains an unsupported file type."
+		if size < 0 or size > MAX_FILE_BYTES: return "The pack offer contains an invalid file size."
+		if not _valid_sha256(sha): return "The pack offer contains an invalid file checksum."
+		paths[path] = true
+		total += size
+		if total > MAX_PACK_BYTES: return "The offered pack is larger than the transfer limit."
+		if path.to_lower() == "dub_video.ogv": has_video = true
+		canonical += "%d:%s:%d:%s\n" % [path.length(), path, size, sha]
+	if not has_video: return "The offered pack has no root-level dub_video.ogv."
+	if int(offer.get("total_bytes", -1)) != total: return "The pack offer's total size is inconsistent."
+	if canonical.length() > MAX_MANIFEST_TEXT or canonical.sha256_text() != pack_id:
+		return "The pack offer's content hash is inconsistent."
+
+	var clips_value: Variant = offer.get("clips", null)
+	if not (clips_value is Array): return "The pack offer has no valid clip list."
+	if Array(clips_value).size() > files.size(): return "The pack offer contains too many selected clips."
+	for clip_value: Variant in clips_value:
+		var clip: String = str(clip_value)
+		if not _safe_relative_path(clip) or not paths.has(clip): return "The pack offer references a missing clip."
+		if not AUDIO_EXTENSIONS.has(clip.get_extension().to_lower()): return "The pack offer references a non-audio clip."
+	return ""
+
+
+func _valid_sha256(value: String) -> bool:
+	if value.length() != 64: return false
+	for i: int in value.length():
+		var c: String = value.substr(i, 1).to_lower()
+		if not "0123456789abcdef".contains(c): return false
+	return true
+
+
+@rpc("authority", "call_remote", "reliable", 1)
+func _rpc_pack_offer_begin(summary: Dictionary) -> void:
+	if _net == null or _net.is_host(): return
+	var offer_id: String = str(summary.get("id", ""))
+	var pack_id: String = str(summary.get("pack_id", ""))
+	var pack_name: String = str(summary.get("name", "Dub pack"))
+	var folder_name: String = str(summary.get("folder_name", ""))
+	var count: int = int(summary.get("file_count", -1))
+	var total: int = int(summary.get("total_bytes", -1))
+	if (offer_id.is_empty() or offer_id.length() > 160 or not _valid_sha256(pack_id)
+		or pack_name.is_empty() or pack_name.length() > 256 or folder_name.length() > 256
+		or count <= 0 or count > MAX_FILES or total < 0 or total > MAX_PACK_BYTES):
+		_active_offer = {"id": offer_id, "pack_id": pack_id, "total_bytes": maxi(0, total)}
+		_client_fail("The host sent an invalid pack summary.")
+		return
+	if str(_active_offer.get("id", "")) == offer_id: return
+	_close_download_file()
+	_incoming_offer = {
+		"id": offer_id,
+		"pack_id": pack_id,
+		"name": pack_name,
+		"folder_name": folder_name,
+		"total_bytes": total,
+		"file_count": count,
+		"ignored": clampi(int(summary.get("ignored", 0)), 0, MAX_FILES),
+	}
+	_incoming_files = []
+	_incoming_page = 0
+	_incoming_manifest_chars = 0
+	_active_offer = _incoming_offer.duplicate(true)
+	_client_state = "checking"
+	_client_error = ""
+	_client_received = 0
+	_queue_render()
+	_send_client_state("checking")
+
+
+@rpc("authority", "call_remote", "reliable", 1)
+func _rpc_pack_offer_files(offer_id: String, page: int, pages: int, files: Array) -> void:
+	if _net == null or _net.is_host() or offer_id != str(_incoming_offer.get("id", "")): return
+	var file_count: int = int(_incoming_offer.get("file_count", 0))
+	var expected_pages: int = int((file_count + MANIFEST_FILES_PER_PAGE - 1) / MANIFEST_FILES_PER_PAGE)
+	var expected_files: int = mini(MANIFEST_FILES_PER_PAGE, file_count - page * MANIFEST_FILES_PER_PAGE)
+	if (page != _incoming_page or pages != expected_pages or files.is_empty()
+		or files.size() != expected_files):
+		_reject_incoming_offer("The host sent the pack manifest out of order.")
+		return
+	var clean_files: Array[Dictionary] = []
+	for value_item: Variant in files:
+		if not (value_item is Dictionary):
+			_reject_incoming_offer("The host sent an invalid pack-manifest entry.")
+			return
+		var item: Dictionary = value_item
+		var path: String = str(item.get("path", ""))
+		var size: int = int(item.get("size", -1))
+		var sha: String = str(item.get("sha256", ""))
+		if (not _safe_relative_path(path) or not SAFE_EXTENSIONS.has(path.get_extension().to_lower())
+			or size < 0 or size > MAX_FILE_BYTES or not _valid_sha256(sha)):
+			_reject_incoming_offer("The host sent an unsafe pack-manifest entry.")
+			return
+		_incoming_manifest_chars += path.length() + sha.length() + 32
+		if _incoming_manifest_chars > MAX_MANIFEST_TEXT:
+			_reject_incoming_offer("The host sent a pack manifest that is too large.")
+			return
+		clean_files.append({"path": path, "size": size, "sha256": sha})
+	_incoming_files.append_array(clean_files)
+	_incoming_page += 1
+
+
+@rpc("authority", "call_remote", "reliable", 1)
+func _rpc_pack_offer_end(offer_id: String, clips: Array) -> void:
+	if _net == null or _net.is_host() or offer_id != str(_incoming_offer.get("id", "")): return
+	if _incoming_files.size() != int(_incoming_offer.get("file_count", -1)):
+		_reject_incoming_offer("The host did not send the complete pack manifest.")
+		return
+	if clips.size() > _incoming_files.size():
+		_reject_incoming_offer("The host sent too many selected clips for this pack.")
+		return
+	var offer: Dictionary = _incoming_offer.duplicate(true)
+	offer.erase("file_count")
+	offer["files"] = _incoming_files.duplicate(true)
+	offer["clips"] = clips.duplicate()
+	var problem: String = _valid_offer(offer)
+	if not problem.is_empty():
+		_active_offer = offer
+		_reject_incoming_offer(problem)
+		return
+	_active_offer = offer
+	_incoming_offer.clear()
+	_incoming_files.clear()
+	_incoming_page = 0
+	_incoming_manifest_chars = 0
+	_check_for_existing_pack.call_deferred(offer_id)
+
+
+func _send_offer_manifest(peer: int, offer_id: String) -> void:
+	if (_net == null or not _net.is_host() or not _net.players.has(peer)
+		or offer_id != str(_active_offer.get("id", ""))): return
+	var files: Array = _active_offer.get("files", [])
+	var summary: Dictionary = {
+		"id": _active_offer["id"],
+		"pack_id": _active_offer["pack_id"],
+		"name": _active_offer["name"],
+		"folder_name": _active_offer["folder_name"],
+		"total_bytes": _active_offer["total_bytes"],
+		"file_count": files.size(),
+		"ignored": _active_offer.get("ignored", 0),
+	}
+	_rpc_pack_offer_begin.rpc_id(peer, summary)
+	var pages: int = int((files.size() + MANIFEST_FILES_PER_PAGE - 1) / MANIFEST_FILES_PER_PAGE)
+	for page: int in pages:
+		if (_net == null or not _net.is_host() or not _net.players.has(peer)
+			or offer_id != str(_active_offer.get("id", ""))): return
+		var first: int = page * MANIFEST_FILES_PER_PAGE
+		var last: int = mini(first + MANIFEST_FILES_PER_PAGE, files.size())
+		_rpc_pack_offer_files.rpc_id(peer, offer_id, page, pages, files.slice(first, last))
+		await get_tree().process_frame
+	if offer_id == str(_active_offer.get("id", "")) and _net.players.has(peer):
+		_rpc_pack_offer_end.rpc_id(peer, offer_id, Array(_active_offer.get("clips", [])))
+
+
+func _check_for_existing_pack(offer_id: String) -> void:
+	if str(_active_offer.get("id", "")) != offer_id: return
+	var candidates: PackedStringArray = []
+	var pack_id: String = str(_active_offer["pack_id"])
+	var cached: String = _cache_path(pack_id)
+	if _cache_marker_matches(cached, pack_id): candidates.append(cached)
+
+	var folder_name: String = str(_active_offer.get("folder_name", ""))
+	if _safe_folder_name(folder_name):
+		var same_name: String = str(FileManager.MODPACKS_VOICE).path_join(folder_name)
+		if DirAccess.dir_exists_absolute(same_name): candidates.append(same_name)
+		var host_manifest: Dictionary = _dictionary(_net.manifests.get(1, {}))
+		var remap: Dictionary = _net.pack_remap(host_manifest)
+		if remap.has(folder_name):
+			var mapped: String = str(FileManager.MODPACKS_VOICE).path_join(str(remap[folder_name]))
+			if not candidates.has(mapped) and DirAccess.dir_exists_absolute(mapped): candidates.append(mapped)
+
+	for candidate: String in candidates:
+		var thread: = Thread.new()
+		var offer_snapshot: Dictionary = _active_offer.duplicate(true)
+		if thread.start(_folder_matches_offer.bind(candidate, offer_snapshot)) != OK: continue
+		var abandoned: bool = false
+		while thread.is_alive():
+			if str(_active_offer.get("id", "")) != offer_id:
+				abandoned = true
+			await get_tree().process_frame
+		var matches: bool = bool(thread.wait_to_finish())
+		if abandoned or str(_active_offer.get("id", "")) != offer_id: return
+		if matches:
+			_pack_paths[pack_id] = candidate
+			_client_state = "ready"
+			_client_received = int(_active_offer["total_bytes"])
+			_queue_render()
+			_send_client_state("ready")
+			pack_ready.emit(pack_id, candidate)
+			return
+
+	if str(_active_offer.get("id", "")) != offer_id: return
+	_client_state = "offered"
+	_queue_render()
+	_send_client_state("offered")
+	if _test_auto_accept: accept_download.call_deferred()
+
+
+func _folder_matches_offer(folder: String, offer: Dictionary) -> bool:
+	for item_value: Variant in Array(offer.get("files", [])):
+		var item: Dictionary = item_value
+		var path: String = folder.path_join(str(item["path"]))
+		if not FileAccess.file_exists(path): return false
+		if _file_size(path) != int(item["size"]): return false
+		if FileAccess.get_sha256(path) != str(item["sha256"]): return false
+	return true
+
+
+func _safe_folder_name(value: String) -> bool:
+	return (not value.is_empty() and value == value.get_file() and value != "." and value != ".."
+		and not value.contains(":") and not value.contains("\\") and not value.contains("/"))
+
+
+func _cache_path(pack_id: String) -> String:
+	return _cache_root.path_join(pack_id)
+
+
+func _cache_marker_matches(folder: String, pack_id: String) -> bool:
+	var marker: String = folder.path_join(COMPLETE_MARKER)
+	if not FileAccess.file_exists(marker): return false
+	return FileAccess.get_file_as_string(marker).strip_edges() == pack_id
+
+
+func accept_download() -> void:
+	if _net == null or _net.is_host(): return
+	if not ["offered", "declined", "failed"].has(_client_state): return
+	var pack_id: String = str(_active_offer.get("pack_id", ""))
+	if not _valid_sha256(pack_id): return
+	if DirAccess.make_dir_recursive_absolute(_cache_path(pack_id)) != OK:
+		_client_fail("Could not create the multiplayer pack cache.")
+		return
+
+	var offsets: Array[int] = []
+	var present: int = 0
+	for value_item: Variant in Array(_active_offer["files"]):
+		var item: Dictionary = value_item
+		var target: String = _cache_path(pack_id).path_join(str(item["path"]))
+		var size: int = _file_size(target) if FileAccess.file_exists(target) else 0
+		if size < 0 or size > int(item["size"]):
+			var reset_file: FileAccess = FileAccess.open(target, FileAccess.WRITE)
+			if reset_file != null: reset_file.close()
+			size = 0
+		offsets.append(size)
+		present += size
+
+	var cache_dir: DirAccess = DirAccess.open(_cache_root)
+	var needed: int = int(_active_offer["total_bytes"]) - present
+	if cache_dir != null:
+		var free: int = cache_dir.get_space_left()
+		if free > 0 and free < needed + FREE_SPACE_MARGIN:
+			_client_fail("Not enough disk space: this download still needs %s." % _format_bytes(needed))
+			return
+
+	_client_state = "downloading"
+	_client_error = ""
+	_client_received = present
+	_client_transfer_id += 1
+	_queue_render()
+	_send_client_state("downloading")
+	_rpc_pack_accept.rpc_id(1, str(_active_offer["id"]), _client_transfer_id, offsets)
+
+
+func decline_download() -> void:
+	if _net == null or _net.is_host(): return
+	if not ["offered", "downloading", "failed"].has(_client_state): return
+	_close_download_file()
+	_client_transfer_id += 1
+	_client_state = "declined"
+	_client_error = ""
+	_queue_render()
+	_send_client_state("declined")
+
+
+@rpc("any_peer", "call_remote", "reliable", 1)
+func _rpc_pack_accept(offer_id: String, client_transfer_id: int, offsets: Array) -> void:
+	if _net == null or not _net.is_host(): return
+	var sender: int = multiplayer.get_remote_sender_id()
+	if not _net.players.has(sender) or offer_id != str(_active_offer.get("id", "")): return
+	var files: Array = _active_offer.get("files", [])
+	if client_transfer_id <= 0 or offsets.size() != files.size():
+		_fail_peer(sender, client_transfer_id, "The resume information did not match this pack.")
+		return
+	for i: int in offsets.size():
+		var offset: int = int(offsets[i])
+		if offset < 0 or offset > int(_dictionary(files[i]).get("size", -1)):
+			_fail_peer(sender, client_transfer_id, "The resume information contained an invalid offset.")
+			return
+
+	_transfer_tokens[sender] = int(_transfer_tokens.get(sender, 0)) + 1
+	var token: int = int(_transfer_tokens[sender])
+	_peer_states[sender] = _state_record("downloading", _sum_offsets(offsets), "")
+	_queue_render()
+	_send_to_peer.call_deferred(sender, offsets.duplicate(), token, client_transfer_id, offer_id)
+
+
+func _send_to_peer(peer: int, offsets: Array, token: int, client_transfer_id: int, offer_id: String) -> void:
+	var files: Array = _active_offer.get("files", [])
+	for i: int in files.size():
+		if not _transfer_is_current(peer, token, offer_id): return
+		var item: Dictionary = files[i]
+		var expected_size: int = int(item["size"])
+		var offset: int = int(offsets[i])
+		var source_path: String = _host_folder.path_join(str(item["path"]))
+		var source: FileAccess = FileAccess.open(source_path, FileAccess.READ)
+		if source == null or source.get_length() != expected_size:
+			_fail_peer(peer, client_transfer_id, "The host could no longer read %s." % str(item["path"]))
+			return
+		source.seek(offset)
+		_host_acks[peer] = {
+			"client_transfer_id": client_transfer_id,
+			"file": i,
+			"offset": offset,
+			"last_msec": Time.get_ticks_msec(),
+		}
+		_rpc_pack_file_begin.rpc_id(peer, offer_id, client_transfer_id, i, offset)
+		var sent: int = offset
+		while sent < expected_size:
+			if not _transfer_is_current(peer, token, offer_id):
+				source.close()
+				return
+			while sent - _ack_offset(peer, i) >= SEND_WINDOW:
+				if not _transfer_is_current(peer, token, offer_id):
+					source.close()
+					return
+				if _ack_stalled(peer):
+					source.close()
+					_fail_peer(peer, client_transfer_id, "The pack download stopped responding for %d seconds." % int(STALL_TIMEOUT_MSEC / 1000))
+					return
+				await get_tree().process_frame
+			var wanted: int = mini(CHUNK_SIZE, expected_size - sent)
+			var chunk: PackedByteArray = source.get_buffer(wanted)
+			if chunk.size() != wanted:
+				source.close()
+				_fail_peer(peer, client_transfer_id, "The host failed while reading %s." % str(item["path"]))
+				return
+			_rpc_pack_chunk.rpc_id(peer, offer_id, client_transfer_id, i, sent, chunk)
+			sent += chunk.size()
+		source.close()
+		while _ack_offset(peer, i) < expected_size:
+			if not _transfer_is_current(peer, token, offer_id): return
+			if _ack_stalled(peer):
+				_fail_peer(peer, client_transfer_id, "The pack download stopped responding for %d seconds." % int(STALL_TIMEOUT_MSEC / 1000))
+				return
+			await get_tree().process_frame
+	if _transfer_is_current(peer, token, offer_id):
+		_rpc_pack_complete.rpc_id(peer, offer_id, client_transfer_id)
+
+
+func _transfer_is_current(peer: int, token: int, offer_id: String) -> bool:
+	if _net == null or not _net.is_online() or not _net.is_host(): return false
+	if offer_id != str(_active_offer.get("id", "")): return false
+	if not _net.players.has(peer): return false
+	if int(_transfer_tokens.get(peer, -1)) != token: return false
+	return str(_dictionary(_peer_states.get(peer, {})).get("state", "")) == "downloading"
+
+
+func _ack_offset(peer: int, file_index: int) -> int:
+	var ack: Dictionary = _dictionary(_host_acks.get(peer, {}))
+	if int(ack.get("file", -1)) != file_index: return 0
+	return int(ack.get("offset", 0))
+
+
+func _ack_stalled(peer: int) -> bool:
+	var ack: Dictionary = _dictionary(_host_acks.get(peer, {}))
+	return Time.get_ticks_msec() - int(ack.get("last_msec", 0)) > STALL_TIMEOUT_MSEC
+
+
+@rpc("authority", "call_remote", "reliable", 1)
+func _rpc_pack_file_begin(offer_id: String, client_transfer_id: int, file_index: int, offset: int) -> void:
+	if _net == null or _net.is_host() or offer_id != str(_active_offer.get("id", "")): return
+	if _client_state != "downloading" or client_transfer_id != _client_transfer_id: return
+	var files: Array = _active_offer.get("files", [])
+	if file_index < 0 or file_index >= files.size():
+		_client_fail("The host selected an invalid file number.")
+		return
+	var item: Dictionary = files[file_index]
+	if offset < 0 or offset > int(item["size"]):
+		_client_fail("The host selected an invalid file offset.")
+		return
+	_close_download_file()
+	var target: String = _cache_path(str(_active_offer["pack_id"])).path_join(str(item["path"]))
+	if DirAccess.make_dir_recursive_absolute(target.get_base_dir()) != OK:
+		_client_fail("Could not create a folder for %s." % str(item["path"]))
+		return
+	var actual: int = _file_size(target) if FileAccess.file_exists(target) else 0
+	if actual != offset:
+		_client_fail("The partial file size changed while resuming %s." % str(item["path"]))
+		return
+	_download_file = FileAccess.open(target, FileAccess.WRITE_READ if offset == 0 else FileAccess.READ_WRITE)
+	if _download_file == null:
+		_client_fail("Could not write %s." % str(item["path"]))
+		return
+	_download_file.seek(offset)
+	_download_index = file_index
+	_download_offset = offset
+
+
+@rpc("authority", "call_remote", "reliable", 1)
+func _rpc_pack_chunk(offer_id: String, client_transfer_id: int, file_index: int, offset: int, data: PackedByteArray) -> void:
+	if _net == null or _net.is_host() or offer_id != str(_active_offer.get("id", "")): return
+	if _client_state != "downloading" or client_transfer_id != _client_transfer_id: return
+	var files: Array = _active_offer.get("files", [])
+	if (_download_file == null or file_index != _download_index or offset != _download_offset
+		or data.is_empty() or data.size() > CHUNK_SIZE or file_index < 0 or file_index >= files.size()
+		or offset + data.size() > int(_dictionary(files[file_index]).get("size", -1))):
+		_client_fail("The host sent an out-of-order or invalid pack chunk.")
+		return
+	_download_file.store_buffer(data)
+	if _download_file.get_error() != OK:
+		_client_fail("The disk write failed while receiving the dub pack.")
+		return
+	_download_offset += data.size()
+	_client_received += data.size()
+	_queue_render()
+	_rpc_pack_ack.rpc_id(1, offer_id, client_transfer_id, file_index, _download_offset, _client_received)
+
+
+@rpc("any_peer", "call_remote", "reliable", 1)
+func _rpc_pack_ack(offer_id: String, client_transfer_id: int, file_index: int, next_offset: int, received: int) -> void:
+	if _net == null or not _net.is_host() or offer_id != str(_active_offer.get("id", "")): return
+	var sender: int = multiplayer.get_remote_sender_id()
+	if not _net.players.has(sender): return
+	var files: Array = _active_offer.get("files", [])
+	if file_index < 0 or file_index >= files.size(): return
+	var ack: Dictionary = _dictionary(_host_acks.get(sender, {}))
+	if int(ack.get("client_transfer_id", -1)) != client_transfer_id or int(ack.get("file", -1)) != file_index: return
+	if next_offset < int(ack.get("offset", 0)) or next_offset > int(_dictionary(files[file_index]).get("size", -1)): return
+	ack["offset"] = next_offset
+	ack["last_msec"] = Time.get_ticks_msec()
+	_host_acks[sender] = ack
+	var record: Dictionary = _dictionary(_peer_states.get(sender, {}))
+	record["received"] = clampi(received, 0, int(_active_offer["total_bytes"]))
+	_peer_states[sender] = record
+	_queue_render()
+
+
+@rpc("authority", "call_remote", "reliable", 1)
+func _rpc_pack_complete(offer_id: String, client_transfer_id: int) -> void:
+	if _net == null or _net.is_host() or offer_id != str(_active_offer.get("id", "")): return
+	if _client_state != "downloading" or client_transfer_id != _client_transfer_id: return
+	_close_download_file()
+	_client_state = "verifying"
+	_queue_render()
+	_send_client_state("verifying")
+	_verify_received_pack.call_deferred(offer_id, client_transfer_id)
+
+
+func _verify_received_pack(offer_id: String, client_transfer_id: int) -> void:
+	var pack_id: String = str(_active_offer.get("pack_id", ""))
+	var folder: String = _cache_path(pack_id)
+	var thread: = Thread.new()
+	var offer_snapshot: Dictionary = _active_offer.duplicate(true)
+	if thread.start(_mismatched_files.bind(folder, offer_snapshot)) != OK:
+		_client_fail("Could not start verification of the downloaded pack.")
+		return
+	var abandoned: bool = false
+	while thread.is_alive():
+		if offer_id != str(_active_offer.get("id", "")) or client_transfer_id != _client_transfer_id:
+			abandoned = true
+		await get_tree().process_frame
+	var mismatched: PackedStringArray = thread.wait_to_finish()
+	if (abandoned or offer_id != str(_active_offer.get("id", ""))
+		or client_transfer_id != _client_transfer_id): return
+	if not mismatched.is_empty():
+		for relative: String in mismatched:
+			var bad: FileAccess = FileAccess.open(folder.path_join(relative), FileAccess.WRITE)
+			if bad != null: bad.close()
+		_client_fail("Verification failed for %d file(s). Click Retry to send those files again." % mismatched.size())
+		return
+
+	var marker: FileAccess = FileAccess.open(folder.path_join(COMPLETE_MARKER), FileAccess.WRITE)
+	if marker == null:
+		_client_fail("The pack verified, but its cache marker could not be written.")
+		return
+	marker.store_string(pack_id)
+	marker.close()
+	_pack_paths[pack_id] = folder
+	_client_state = "ready"
+	_client_received = int(_active_offer["total_bytes"])
+	_queue_render()
+	_send_client_state("ready")
+	pack_ready.emit(pack_id, folder)
+
+
+func _mismatched_files(folder: String, offer: Dictionary) -> PackedStringArray:
+	var out: PackedStringArray = []
+	for value_item: Variant in Array(offer.get("files", [])):
+		var item: Dictionary = value_item
+		var target: String = folder.path_join(str(item["path"]))
+		if (not FileAccess.file_exists(target) or _file_size(target) != int(item["size"])
+			or FileAccess.get_sha256(target) != str(item["sha256"])):
+			out.append(str(item["path"]))
+	return out
+
+
+@rpc("any_peer", "call_remote", "reliable", 1)
+func _rpc_pack_state(offer_id: String, state: String, received: int, error: String) -> void:
+	if _net == null or not _net.is_host() or offer_id != str(_active_offer.get("id", "")): return
+	var sender: int = multiplayer.get_remote_sender_id()
+	if not _net.players.has(sender): return
+	if not ["checking", "offered", "declined", "downloading", "verifying", "ready", "failed"].has(state): return
+	_peer_states[sender] = _state_record(state, clampi(received, 0, int(_active_offer["total_bytes"])), error.substr(0, 300))
+	if state != "downloading": _transfer_tokens[sender] = int(_transfer_tokens.get(sender, 0)) + 1
+	_queue_render()
+
+
+func _send_client_state(state: String) -> void:
+	if _net == null or not _net.is_online() or _net.is_host() or _active_offer.is_empty(): return
+	_rpc_pack_state.rpc_id(1, str(_active_offer["id"]), state, _client_received, _client_error)
+
+
+func _client_fail(reason: String) -> void:
+	_close_download_file()
+	_client_transfer_id += 1
+	_client_state = "failed"
+	_client_error = reason.substr(0, 300)
+	_queue_render()
+	_send_client_state("failed")
+	if _net != null: _net.log_net("pack sync failed: %s" % reason)
+
+
+func _reject_incoming_offer(reason: String) -> void:
+	_incoming_offer.clear()
+	_incoming_files.clear()
+	_incoming_page = 0
+	_incoming_manifest_chars = 0
+	_client_fail(reason)
+
+
+func _fail_peer(peer: int, client_transfer_id: int, reason: String) -> void:
+	_transfer_tokens[peer] = int(_transfer_tokens.get(peer, 0)) + 1
+	_peer_states[peer] = _state_record("failed", int(_dictionary(_peer_states.get(peer, {})).get("received", 0)), reason)
+	_rpc_pack_error.rpc_id(peer, str(_active_offer.get("id", "")), client_transfer_id, reason)
+	_queue_render()
+
+
+@rpc("authority", "call_remote", "reliable", 1)
+func _rpc_pack_error(offer_id: String, client_transfer_id: int, reason: String) -> void:
+	if _net == null or _net.is_host() or offer_id != str(_active_offer.get("id", "")): return
+	if client_transfer_id != _client_transfer_id: return
+	_client_fail(reason)
+
+
+@rpc("authority", "call_remote", "reliable", 1)
+func _rpc_pack_cancel(offer_id: String, reason: String) -> void:
+	if _net == null or _net.is_host(): return
+	if (offer_id != str(_active_offer.get("id", ""))
+		and offer_id != str(_incoming_offer.get("id", ""))): return
+	_close_download_file()
+	_client_state = "idle"
+	_client_error = reason
+	_active_offer.clear()
+	_incoming_offer.clear()
+	_incoming_files.clear()
+	_incoming_manifest_chars = 0
+	_hide_panel.call_deferred()
+	_emit_state_changed.call_deferred()
+
+
+func _cancel_host_offer(reason: String) -> void:
+	if _active_offer.is_empty(): return
+	_rpc_pack_cancel.rpc(str(_active_offer["id"]), reason)
+	_net.log_net("canceled dub-pack offer: %s" % reason)
+	reset()
+
+
+func _on_roster_changed() -> void:
+	if _net == null or not _net.is_host() or _active_offer.is_empty(): return
+	var current: Dictionary = {}
+	for peer: int in _net.players:
+		current[peer] = true
+		if peer != 1 and not _peer_states.has(peer):
+			_peer_states[peer] = _state_record("checking", 0, "")
+			_send_offer_later.call_deferred(peer, str(_active_offer["id"]))
+	for peer_value: Variant in _peer_states.keys():
+		var peer: int = int(peer_value)
+		if not current.has(peer):
+			_peer_states.erase(peer)
+			_host_acks.erase(peer)
+			_transfer_tokens[peer] = int(_transfer_tokens.get(peer, 0)) + 1
+	_queue_render()
+
+
+func _send_offer_later(peer: int, offer_id: String) -> void:
+	await get_tree().create_timer(0.5).timeout
+	if (_net != null and _net.is_host() and _net.players.has(peer)
+		and offer_id == str(_active_offer.get("id", ""))):
+		_send_offer_manifest(peer, offer_id)
+
+
+func _all_players_ready() -> bool:
+	if _net == null or _net.players.size() < 2: return false
+	for peer: int in _net.players:
+		if peer == 1: continue
+		if str(_dictionary(_peer_states.get(peer, {})).get("state", "")) != "ready": return false
+	return true
+
+
+func _state_record(state: String, received: int, error: String) -> Dictionary:
+	return {"state": state, "received": received, "error": error}
+
+
+func _sum_offsets(offsets: Array) -> int:
+	var total: int = 0
+	for value: Variant in offsets: total += int(value)
+	return total
+
+
+func _dictionary(value: Variant) -> Dictionary:
+	return value if value is Dictionary else {}
+
+
+func _file_size(path: String) -> int:
+	var file: FileAccess = FileAccess.open(path, FileAccess.READ)
+	if file == null: return -1
+	var size: int = file.get_length()
+	file.close()
+	return size
+
+
+func _close_download_file() -> void:
+	if _download_file != null:
+		_download_file.flush()
+		_download_file.close()
+	_download_file = null
+	_download_index = -1
+	_download_offset = 0
+
+
+func _hide_panel() -> void:
+	if is_instance_valid(_panel): _panel.visible = false
+
+
+func _emit_state_changed() -> void:
+	state_changed.emit()
+
+
+func _build_ui() -> void:
+	_layer = CanvasLayer.new()
+	_layer.layer = 140
+	add_child(_layer)
+
+	_panel = PanelContainer.new()
+	_panel.anchor_left = 0.5
+	_panel.anchor_right = 0.5
+	_panel.offset_left = -380
+	_panel.offset_right = 380
+	_panel.offset_top = 48
+	_panel.visible = false
+	_layer.add_child(_panel)
+
+	var margin: = MarginContainer.new()
+	for side: String in ["left", "right", "top", "bottom"]:
+		margin.add_theme_constant_override("margin_" + side, 18)
+	_panel.add_child(margin)
+
+	var column: = VBoxContainer.new()
+	column.add_theme_constant_override("separation", 8)
+	margin.add_child(column)
+
+	_title = Label.new()
+	_title.add_theme_font_size_override("font_size", 24)
+	column.add_child(_title)
+
+	_detail = Label.new()
+	_detail.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
+	column.add_child(_detail)
+
+	_roster = Label.new()
+	_roster.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
+	column.add_child(_roster)
+
+	_progress = ProgressBar.new()
+	_progress.show_percentage = true
+	column.add_child(_progress)
+
+	var buttons: = HBoxContainer.new()
+	buttons.add_theme_constant_override("separation", 8)
+	column.add_child(buttons)
+
+	_primary = Button.new()
+	_primary.pressed.connect(_on_primary)
+	buttons.add_child(_primary)
+
+	_secondary = Button.new()
+	_secondary.pressed.connect(_on_secondary)
+	buttons.add_child(_secondary)
+
+
+func _show_scanning() -> void:
+	_panel.visible = true
+	_title.text = "PREPARING DUB PACK"
+	_detail.text = "Checking the selected pack and calculating its content hash..."
+	_roster.text = ""
+	_progress.visible = false
+	_primary.visible = false
+	_secondary.visible = true
+	_secondary.text = "Cancel"
+	_secondary.disabled = false
+
+
+func _show_host_error(reason: String) -> void:
+	_host_decision = -1
+	_panel.visible = true
+	_title.text = "PACK CANNOT BE SHARED"
+	_detail.text = reason
+	_roster.text = ""
+	_progress.visible = false
+	_primary.visible = false
+	_secondary.visible = true
+	_secondary.text = "Close"
+	_secondary.disabled = false
+	if _net != null: _net.log_net("cannot offer dub pack: %s" % reason)
+
+
+func _queue_render() -> void:
+	if _render_queued: return
+	_render_queued = true
+	_render_deferred.call_deferred()
+
+
+func _render_deferred() -> void:
+	_render_queued = false
+	_render()
+
+
+func _render() -> void:
+	if not is_instance_valid(_panel) or _active_offer.is_empty(): return
+	_panel.visible = true
+	var total: int = int(_active_offer.get("total_bytes", 0))
+	if _net != null and _net.is_host():
+		_title.text = "SHARE DUB PACK"
+		_detail.text = "%s — %s. Everyone must have and verify this pack before the dub can begin." % [
+			_active_offer.get("name", "Dub pack"), _format_bytes(total)]
+		var ignored: int = int(_active_offer.get("ignored", 0))
+		if ignored > 0:
+			_detail.text += " %d generated or unsupported file(s) will not be copied." % ignored
+		var lines: PackedStringArray = []
+		for slot: int in _net.slot_count():
+			var peer: int = _net.peer_for_slot(slot)
+			var record: Dictionary = _dictionary(_peer_states.get(peer, {}))
+			var state: String = str(record.get("state", "checking"))
+			var status: String = _state_label(state)
+			if state == "downloading":
+				status += " %d%%" % _percent(int(record.get("received", 0)), total)
+			if state == "failed" and not str(record.get("error", "")).is_empty():
+				status += " — " + str(record["error"])
+			lines.append("%s: %s" % [_net.player_name_for_slot(slot), status])
+		_roster.text = "\n".join(lines)
+		_progress.visible = false
+		_primary.visible = true
+		_primary.text = "Begin dub"
+		_primary.disabled = not _all_players_ready()
+		_secondary.visible = true
+		_secondary.text = "Cancel"
+		_secondary.disabled = false
+	else:
+		_title.text = "HOST SELECTED A DUB PACK"
+		_detail.text = "%s — %s" % [_active_offer.get("name", "Dub pack"), _format_bytes(total)]
+		_roster.text = _client_status_text()
+		_progress.visible = _client_state in ["downloading", "verifying", "ready"]
+		_progress.min_value = 0
+		_progress.max_value = maxi(1, total)
+		_progress.value = _client_received
+		_primary.visible = _client_state in ["offered", "declined", "failed"]
+		_primary.text = "Retry download" if _client_state == "failed" else "Download pack"
+		_primary.disabled = false
+		_secondary.visible = _client_state in ["offered", "downloading"]
+		_secondary.text = "Cancel download" if _client_state == "downloading" else "Not now"
+		_secondary.disabled = false
+	state_changed.emit()
+
+
+func _client_status_text() -> String:
+	match _client_state:
+		"checking": return "Checking whether this pack is already installed..."
+		"offered": return "This pack is missing. It will be kept in the multiplayer cache, not installed into your pack library."
+		"declined": return "Download declined. You can change your mind while the host is still waiting."
+		"downloading": return "Downloading from the host: %s / %s" % [
+			_format_bytes(_client_received),
+			_format_bytes(int(_active_offer.get("total_bytes", 0))),
+		]
+		"verifying": return "Download complete. Verifying every file..."
+		"ready": return "Pack ready. Waiting for the host to begin the dub."
+		"failed": return _client_error
+	return "Waiting for the host..."
+
+
+func _state_label(state: String) -> String:
+	match state:
+		"ready": return "ready"
+		"checking": return "checking installed packs"
+		"offered": return "waiting for their answer"
+		"declined": return "declined"
+		"downloading": return "downloading"
+		"verifying": return "verifying"
+		"failed": return "failed"
+	return state
+
+
+func _on_primary() -> void:
+	if _net != null and _net.is_host():
+		if _all_players_ready(): _host_decision = 1
+	else:
+		accept_download()
+
+
+func _on_secondary() -> void:
+	if _net != null and _net.is_host():
+		if _active_offer.is_empty():
+			_host_decision = -1
+			_panel.visible = false
+		else:
+			_host_decision = -1
+	else:
+		decline_download()
+
+
+func _percent(value: int, total: int) -> int:
+	if total <= 0: return 0
+	return clampi(int(float(value) * 100.0 / float(total)), 0, 100)
+
+
+func _format_bytes(bytes: int) -> String:
+	if bytes >= 1024 * 1024 * 1024: return "%.2f GB" % (float(bytes) / 1073741824.0)
+	if bytes >= 1024 * 1024: return "%.1f MB" % (float(bytes) / 1048576.0)
+	if bytes >= 1024: return "%.1f KB" % (float(bytes) / 1024.0)
+	return "%d bytes" % bytes

--- a/mod/net/pack_sync.gd
+++ b/mod/net/pack_sync.gd
@@ -1032,7 +1032,8 @@ func _show_scanning() -> void:
 	_panel.visible = true
 	_title.text = "EXPERIMENTAL DUB PACK SHARING"
 	_detail.text = ("Preparing the selected pack. Sharing is experimental: large transfers may be slow "
-		+ "or cause disconnects on weaker connections. Nothing will be offered until you confirm.")
+		+ "or cause disconnects on weaker connections. Only use it when everyone trusts the host and "
+		+ "the source of the pack. Nothing will be offered until you confirm.")
 	_roster.text = ""
 	_progress.visible = false
 	_primary.visible = false
@@ -1073,7 +1074,8 @@ func _render() -> void:
 	if _net != null and _net.is_host():
 		_title.text = "EXPERIMENTAL DUB PACK SHARING"
 		_detail.text = ("%s — %s. Host-to-player pack sharing is experimental. Large transfers may "
-			+ "be slow or cause disconnects on weaker connections.") % [
+			+ "be slow or cause disconnects on weaker connections. Only use it when everyone trusts "
+			+ "the host and the source of this pack.") % [
 			_active_offer.get("name", "Dub pack"), _format_bytes(total)]
 		var ignored: int = int(_active_offer.get("ignored", 0))
 		if ignored > 0:
@@ -1105,7 +1107,7 @@ func _render() -> void:
 	else:
 		_title.text = "EXPERIMENTAL PACK DOWNLOAD"
 		_detail.text = ("%s — %s. Host-to-player sharing is experimental and may be slow or "
-			+ "disconnect on unstable connections.") % [
+			+ "disconnect on unstable connections. Only download packs from a host you trust.") % [
 			_active_offer.get("name", "Dub pack"), _format_bytes(total)]
 		_roster.text = _client_status_text()
 		_progress.visible = _client_state in ["downloading", "verifying", "ready"]

--- a/mod/net/pack_sync.gd
+++ b/mod/net/pack_sync.gd
@@ -62,10 +62,13 @@ var _panel_dismissed: bool = true
 var _force_fresh_pending: bool = false
 
 var _layer: CanvasLayer
+var _modal_root: Control
 var _panel: PanelContainer
 var _title: Label
 var _detail: Label
+var _warning_box: PanelContainer
 var _warning: Label
+var _roster_box: PanelContainer
 var _roster: Label
 var _force_download_box: CheckBox
 var _progress: ProgressBar
@@ -1005,6 +1008,7 @@ func _close_download_file() -> void:
 
 
 func _hide_panel() -> void:
+	if is_instance_valid(_modal_root): _modal_root.visible = false
 	if is_instance_valid(_panel): _panel.visible = false
 
 
@@ -1022,40 +1026,76 @@ func _build_ui() -> void:
 	_layer.layer = 140
 	add_child(_layer)
 
+	_modal_root = Control.new()
+	_modal_root.set_anchors_and_offsets_preset(Control.PRESET_TOP_LEFT)
+	_modal_root.position = Vector2.ZERO
+	_modal_root.size = get_viewport().get_visible_rect().size
+	get_viewport().size_changed.connect(func() -> void:
+		if is_instance_valid(_modal_root):
+			_modal_root.position = Vector2.ZERO
+			_modal_root.size = get_viewport().get_visible_rect().size)
+	_modal_root.mouse_filter = Control.MOUSE_FILTER_STOP
+	_modal_root.visible = false
+	_layer.add_child(_modal_root)
+
+	var backdrop: = ColorRect.new()
+	backdrop.color = Color(0.015, 0.025, 0.055, 0.82)
+	backdrop.set_anchors_and_offsets_preset(Control.PRESET_FULL_RECT)
+	_modal_root.add_child(backdrop)
+
+	var center: = CenterContainer.new()
+	center.set_anchors_and_offsets_preset(Control.PRESET_FULL_RECT)
+	_modal_root.add_child(center)
+
 	_panel = PanelContainer.new()
-	_panel.anchor_left = 0.5
-	_panel.anchor_right = 0.5
-	_panel.offset_left = -380
-	_panel.offset_right = 380
-	_panel.offset_top = 48
+	_panel.custom_minimum_size = Vector2(700, 0)
+	_panel.add_theme_stylebox_override("panel", _style_box(
+		Color("111827"), 14, Color("3b4b6b"), 1, 0))
 	_panel.visible = false
-	_layer.add_child(_panel)
+	center.add_child(_panel)
 
 	var margin: = MarginContainer.new()
 	for side: String in ["left", "right", "top", "bottom"]:
-		margin.add_theme_constant_override("margin_" + side, 18)
+		margin.add_theme_constant_override("margin_" + side, 24)
 	_panel.add_child(margin)
 
 	var column: = VBoxContainer.new()
-	column.add_theme_constant_override("separation", 8)
+	column.add_theme_constant_override("separation", 12)
 	margin.add_child(column)
 
+	var eyebrow: = Label.new()
+	eyebrow.text = "MULTIPLAYER  •  DUB MODE"
+	eyebrow.add_theme_font_size_override("font_size", 13)
+	eyebrow.add_theme_color_override("font_color", Color("61c4ff"))
+	column.add_child(eyebrow)
+
 	_title = Label.new()
-	_title.add_theme_font_size_override("font_size", 24)
+	_title.add_theme_font_size_override("font_size", 28)
+	_title.add_theme_color_override("font_color", Color("f3f5fb"))
 	column.add_child(_title)
 
 	_detail = Label.new()
 	_detail.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
+	_detail.add_theme_color_override("font_color", Color("c5ccda"))
 	column.add_child(_detail)
 
+	_warning_box = PanelContainer.new()
+	_warning_box.add_theme_stylebox_override("panel", _style_box(
+		Color("352d19"), 8, Color("8c7130"), 1, 12))
+	column.add_child(_warning_box)
 	_warning = Label.new()
 	_warning.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
-	_warning.add_theme_color_override("font_color", Color("ffcc44"))
-	column.add_child(_warning)
+	_warning.add_theme_color_override("font_color", Color("ffd36a"))
+	_warning_box.add_child(_warning)
 
+	_roster_box = PanelContainer.new()
+	_roster_box.add_theme_stylebox_override("panel", _style_box(
+		Color("192235"), 8, Color("33425f"), 1, 12))
+	column.add_child(_roster_box)
 	_roster = Label.new()
 	_roster.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
-	column.add_child(_roster)
+	_roster.add_theme_color_override("font_color", Color("edf1f8"))
+	_roster_box.add_child(_roster)
 
 	_force_download_box = CheckBox.new()
 	_force_download_box.text = "Force fresh download for testing"
@@ -1068,27 +1108,70 @@ func _build_ui() -> void:
 	column.add_child(_progress)
 
 	var buttons: = HBoxContainer.new()
+	buttons.alignment = BoxContainer.ALIGNMENT_END
 	buttons.add_theme_constant_override("separation", 8)
 	column.add_child(buttons)
 
 	_primary = Button.new()
+	_style_button(_primary, true)
 	_primary.pressed.connect(_on_primary)
 	buttons.add_child(_primary)
 
 	_secondary = Button.new()
+	_style_button(_secondary, false)
 	_secondary.pressed.connect(_on_secondary)
 	buttons.add_child(_secondary)
 
 
+func _style_button(button: Button, primary: bool) -> void:
+	var accent: Color = Color("61c4ff")
+	button.custom_minimum_size = Vector2(120, 40)
+	button.add_theme_font_size_override("font_size", 14)
+	button.add_theme_color_override("font_color", Color("071019") if primary else Color("f3f5fb"))
+	button.add_theme_color_override("font_hover_color", Color("071019") if primary else Color("f3f5fb"))
+	button.add_theme_stylebox_override("normal", _style_box(
+		accent if primary else Color("202b42"), 7, accent if primary else Color("3b4b6b"), 1, 10))
+	button.add_theme_stylebox_override("hover", _style_box(
+		accent.lightened(0.15) if primary else Color("293650"), 7, accent, 1, 10))
+	button.add_theme_stylebox_override("pressed", _style_box(
+		accent.darkened(0.1) if primary else Color("1b263b"), 7, accent, 2, 10))
+
+
+func _style_box(color: Color, radius: int, border: Color, width: int, margin_size: int) -> StyleBoxFlat:
+	var box: = StyleBoxFlat.new()
+	box.bg_color = color
+	box.corner_radius_top_left = radius
+	box.corner_radius_top_right = radius
+	box.corner_radius_bottom_left = radius
+	box.corner_radius_bottom_right = radius
+	box.border_width_left = width
+	box.border_width_right = width
+	box.border_width_top = width
+	box.border_width_bottom = width
+	box.border_color = border
+	box.content_margin_left = margin_size
+	box.content_margin_right = margin_size
+	box.content_margin_top = margin_size
+	box.content_margin_bottom = margin_size
+	return box
+
+
+func _show_panel() -> void:
+	_modal_root.visible = true
+	_panel.visible = true
+
+
 func _show_scanning() -> void:
 	_panel_dismissed = false
-	_panel.visible = true
+	_show_panel()
 	_title.text = "DUB PACK SHARING"
 	_detail.text = "Checking the selected pack and calculating its content hash..."
 	_warning.visible = true
+	_warning_box.visible = true
 	_warning.text = ("EXPERIMENTAL: Large transfers may be slow or disconnect weaker connections. "
 		+ "Only share packs from sources you trust.")
 	_roster.text = ""
+	_roster_box.visible = false
 	_force_download_box.button_pressed = false
 	_force_download_box.visible = false
 	_progress.visible = false
@@ -1101,11 +1184,13 @@ func _show_scanning() -> void:
 func _show_host_error(reason: String) -> void:
 	_host_decision = -1
 	_panel_dismissed = false
-	_panel.visible = true
+	_show_panel()
 	_title.text = "PACK CANNOT BE SHARED"
 	_detail.text = reason
 	_warning.visible = false
+	_warning_box.visible = false
 	_roster.text = ""
+	_roster_box.visible = false
 	_force_download_box.visible = false
 	_progress.visible = false
 	_primary.visible = false
@@ -1133,14 +1218,17 @@ func _development_controls_enabled() -> bool:
 func _render() -> void:
 	if not is_instance_valid(_panel) or _active_offer.is_empty(): return
 	if _panel_dismissed:
+		_modal_root.visible = false
 		_panel.visible = false
 		return
-	_panel.visible = true
+	_show_panel()
+	_roster_box.visible = true
 	var total: int = int(_active_offer.get("total_bytes", 0))
 	if _net != null and _net.is_host():
 		_title.text = "DUB PACK SHARING"
 		_detail.text = "%s — %s" % [_active_offer.get("name", "Dub pack"), _format_bytes(total)]
 		_warning.visible = true
+		_warning_box.visible = true
 		_warning.text = ("EXPERIMENTAL: Large transfers may be slow or disconnect weaker connections. "
 			+ "Only share packs from sources you trust.")
 		var ignored: int = int(_active_offer.get("ignored", 0))
@@ -1176,6 +1264,7 @@ func _render() -> void:
 		_title.text = "DUB PACK DOWNLOAD"
 		_detail.text = "%s — %s" % [_active_offer.get("name", "Dub pack"), _format_bytes(total)]
 		_warning.visible = true
+		_warning_box.visible = true
 		_warning.text = ("EXPERIMENTAL: Transfers may be slow or disconnect unstable connections. "
 			+ "Only download packs from a host you trust.")
 		_roster.text = _client_status_text()

--- a/mod/net/pack_sync.gd
+++ b/mod/net/pack_sync.gd
@@ -48,6 +48,7 @@ var _transfer_tokens: Dictionary = {}
 var _offer_serial: int = 0
 var _prepare_generation: int = 0
 var _host_decision: int = 0
+var _host_sharing_confirmed: bool = false
 
 var _client_state: String = "idle"
 var _client_error: String = ""
@@ -106,6 +107,7 @@ func reset() -> void:
 	_host_acks.clear()
 	_transfer_tokens.clear()
 	_host_decision = -1
+	_host_sharing_confirmed = false
 	_client_state = "idle"
 	_client_error = ""
 	_client_received = 0
@@ -144,6 +146,7 @@ func prepare_dub(folder: String, clip_paths: PackedStringArray) -> Dictionary:
 
 	_host_folder = folder.trim_suffix("/").replace("\\", "/")
 	_host_decision = 0
+	_host_sharing_confirmed = false
 	_client_error = ""
 	_show_scanning()
 
@@ -197,8 +200,6 @@ func prepare_dub(folder: String, clip_paths: PackedStringArray) -> Dictionary:
 	_net.log_net("offering dub pack '%s' (%s, %d files)" % [
 		_active_offer["name"], _format_bytes(int(_active_offer["total_bytes"])),
 		Array(_active_offer["files"]).size()])
-	for peer: int in _net.players:
-		if peer != 1: _send_offer_manifest.call_deferred(peer, str(_active_offer["id"]))
 	_queue_render()
 
 	while _host_decision == 0:
@@ -206,6 +207,7 @@ func prepare_dub(folder: String, clip_paths: PackedStringArray) -> Dictionary:
 		if not _net.is_online() or not _net.is_host():
 			reset()
 			return {}
+		if _test_auto_begin and not _host_sharing_confirmed: _begin_host_sharing()
 		if _test_auto_begin and _all_players_ready(): _host_decision = 1
 		await get_tree().process_frame
 
@@ -463,7 +465,8 @@ func _rpc_pack_offer_end(offer_id: String, clips: Array) -> void:
 
 
 func _send_offer_manifest(peer: int, offer_id: String) -> void:
-	if (_net == null or not _net.is_host() or not _net.players.has(peer)
+	if (_net == null or not _net.is_host() or not _host_sharing_confirmed
+		or not _net.players.has(peer)
 		or offer_id != str(_active_offer.get("id", ""))): return
 	var files: Array = _active_offer.get("files", [])
 	var summary: Dictionary = {
@@ -907,7 +910,8 @@ func _on_roster_changed() -> void:
 		current[peer] = true
 		if peer != 1 and not _peer_states.has(peer):
 			_peer_states[peer] = _state_record("checking", 0, "")
-			_send_offer_later.call_deferred(peer, str(_active_offer["id"]))
+			if _host_sharing_confirmed:
+				_send_offer_later.call_deferred(peer, str(_active_offer["id"]))
 	for peer_value: Variant in _peer_states.keys():
 		var peer: int = int(peer_value)
 		if not current.has(peer):
@@ -920,6 +924,7 @@ func _on_roster_changed() -> void:
 func _send_offer_later(peer: int, offer_id: String) -> void:
 	await get_tree().create_timer(0.5).timeout
 	if (_net != null and _net.is_host() and _net.players.has(peer)
+		and _host_sharing_confirmed
 		and offer_id == str(_active_offer.get("id", ""))):
 		_send_offer_manifest(peer, offer_id)
 
@@ -1025,8 +1030,9 @@ func _build_ui() -> void:
 
 func _show_scanning() -> void:
 	_panel.visible = true
-	_title.text = "PREPARING DUB PACK"
-	_detail.text = "Checking the selected pack and calculating its content hash..."
+	_title.text = "EXPERIMENTAL DUB PACK SHARING"
+	_detail.text = ("Preparing the selected pack. Sharing is experimental: large transfers may be slow "
+		+ "or cause disconnects on weaker connections. Nothing will be offered until you confirm.")
 	_roster.text = ""
 	_progress.visible = false
 	_primary.visible = false
@@ -1065,34 +1071,42 @@ func _render() -> void:
 	_panel.visible = true
 	var total: int = int(_active_offer.get("total_bytes", 0))
 	if _net != null and _net.is_host():
-		_title.text = "SHARE DUB PACK"
-		_detail.text = "%s — %s. Everyone must have and verify this pack before the dub can begin." % [
+		_title.text = "EXPERIMENTAL DUB PACK SHARING"
+		_detail.text = ("%s — %s. Host-to-player pack sharing is experimental. Large transfers may "
+			+ "be slow or cause disconnects on weaker connections.") % [
 			_active_offer.get("name", "Dub pack"), _format_bytes(total)]
 		var ignored: int = int(_active_offer.get("ignored", 0))
 		if ignored > 0:
 			_detail.text += " %d generated or unsupported file(s) will not be copied." % ignored
-		var lines: PackedStringArray = []
-		for slot: int in _net.slot_count():
-			var peer: int = _net.peer_for_slot(slot)
-			var record: Dictionary = _dictionary(_peer_states.get(peer, {}))
-			var state: String = str(record.get("state", "checking"))
-			var status: String = _state_label(state)
-			if state == "downloading":
-				status += " %d%%" % _percent(int(record.get("received", 0)), total)
-			if state == "failed" and not str(record.get("error", "")).is_empty():
-				status += " — " + str(record["error"])
-			lines.append("%s: %s" % [_net.player_name_for_slot(slot), status])
-		_roster.text = "\n".join(lines)
+		if not _host_sharing_confirmed:
+			_roster.text = ("No pack offer has been sent. Enabling sharing lets each player choose "
+				+ "whether to download it; the dub will remain blocked until everyone is ready.")
+		else:
+			_detail.text += " Everyone must have and verify this pack before the dub can begin."
+			var lines: PackedStringArray = []
+			for slot: int in _net.slot_count():
+				var peer: int = _net.peer_for_slot(slot)
+				var record: Dictionary = _dictionary(_peer_states.get(peer, {}))
+				var state: String = str(record.get("state", "checking"))
+				var status: String = _state_label(state)
+				if state == "downloading":
+					status += " %d%%" % _percent(int(record.get("received", 0)), total)
+				if state == "failed" and not str(record.get("error", "")).is_empty():
+					status += " — " + str(record["error"])
+				lines.append("%s: %s" % [_net.player_name_for_slot(slot), status])
+			_roster.text = "\n".join(lines)
 		_progress.visible = false
 		_primary.visible = true
-		_primary.text = "Begin dub"
-		_primary.disabled = not _all_players_ready()
+		_primary.text = "Begin dub" if _host_sharing_confirmed else "Enable experimental sharing"
+		_primary.disabled = _host_sharing_confirmed and not _all_players_ready()
 		_secondary.visible = true
 		_secondary.text = "Cancel"
 		_secondary.disabled = false
 	else:
-		_title.text = "HOST SELECTED A DUB PACK"
-		_detail.text = "%s — %s" % [_active_offer.get("name", "Dub pack"), _format_bytes(total)]
+		_title.text = "EXPERIMENTAL PACK DOWNLOAD"
+		_detail.text = ("%s — %s. Host-to-player sharing is experimental and may be slow or "
+			+ "disconnect on unstable connections.") % [
+			_active_offer.get("name", "Dub pack"), _format_bytes(total)]
 		_roster.text = _client_status_text()
 		_progress.visible = _client_state in ["downloading", "verifying", "ready"]
 		_progress.min_value = 0
@@ -1136,9 +1150,19 @@ func _state_label(state: String) -> String:
 
 func _on_primary() -> void:
 	if _net != null and _net.is_host():
-		if _all_players_ready(): _host_decision = 1
+		if not _host_sharing_confirmed: _begin_host_sharing()
+		elif _all_players_ready(): _host_decision = 1
 	else:
 		accept_download()
+
+
+func _begin_host_sharing() -> void:
+	if (_net == null or not _net.is_host() or _active_offer.is_empty()
+		or _host_sharing_confirmed): return
+	_host_sharing_confirmed = true
+	for peer: int in _net.players:
+		if peer != 1: _send_offer_manifest.call_deferred(peer, str(_active_offer["id"]))
+	_queue_render()
 
 
 func _on_secondary() -> void:

--- a/mod/patches/common/scenes__nav_specific__clip_selector_menus__clip_selection_dub.gd.patch
+++ b/mod/patches/common/scenes__nav_specific__clip_selector_menus__clip_selection_dub.gd.patch
@@ -1,6 +1,6 @@
 --- a/scenes/nav_specific/clip_selector_menus/clip_selection_dub.gd
 +++ b/scenes/nav_specific/clip_selector_menus/clip_selection_dub.gd
-@@ -37,7 +37,19 @@
+@@ -37,6 +37,20 @@
  
  
  func initiate_session() -> void :
@@ -14,8 +14,10 @@
 +		var paths: PackedStringArray = []
 +		for c: OmniClip in Metro.gameplay_resource_dub_mode.omni_clip_array.data:
 +			paths.append(c.self_global_path)
++		var prepared: Dictionary = await Net.prepare_dub_pack(tree.active_pack.global_folder_path, paths)
++		if prepared.is_empty(): return
 +		Net.apply_roster_to_metro()
-+		Net.start_dub(tree.active_pack.global_folder_path, paths)
++		Net.start_dub(str(prepared["pack_id"]), PackedStringArray(prepared["clip_paths"]))
  	match M.session_type:
  
  


### PR DESCRIPTION
## Summary

This adds two related experimental Dub Mode workflows:

- opt-in host-to-client synchronization for the selected dub pack, so every player no longer has to install that pack before joining; and
- a native in-game GameBanana browser for finding, downloading, installing, and removing community dub packs.

The lobby mismatch copy now distinguishes Standard Mode requirements from Dub Mode sharing, and the mod moves to `1.2.0-dev` / protocol 8 because Dub Mode start packets now use a content ID and relative clip paths instead of the host's absolute paths.

## Host pack sharing

- The host must explicitly enable experimental sharing after selecting a pack.
- Each client sees the pack name, size, and trust warning and can accept or decline. Declining is reversible while the host is waiting.
- The host sees each player's state and cannot begin until every connected player has verified the selected pack.
- Transfers use 24 KiB chunks with a 96 KiB acknowledged send window, per-client progress, a stall timeout, and resumable partial files.
- Packs are content-addressed, cached under `user://multiplayer_pack_cache`, and reused after successful verification.
- A development-only **Force fresh download for testing** option exercises the transfer even when both local instances can already see the same pack.
- The transfer protocol lives on a `PackSync` child so its RPC list cannot move the existing compatibility handshake.

## Community pack browser

- Adds a native GameBanana Dub Mode catalog with browse, sort, search, content-rating filtering, previews, file selection, and submission links.
- Adds a persistent sequential download queue with progress, cancel, retry, and background operation after the browser closes.
- Queued downloads wait during online multiplayer by default. Players can persistently opt into online starts with an explicit latency warning; disabling the option does not interrupt the active transfer.
- Handles both wrapped and flat ZIP layouts, always installing into a dedicated pack folder.
- Adds an **Installed** library with creator/date/size metadata, GameBanana links, refresh, and guarded uninstall without rediscovering the submission.
- Exposes the browser from the normal main menu and online screen, with best-effort runtime integration into Extras.
- Constrains community-provided titles and filenames so long values cannot widen the UI beyond the viewport.

## Security boundaries

Host transfers require explicit consent and warn clients to accept only from hosts they trust. They reject unsafe paths and unknown/executable/archive formats, limit file/pack counts and sizes, check free space, and verify every file with SHA-256 before marking the pack ready.

GameBanana installs are ZIP-only. Before extraction they require GameBanana analysis and AV approval, verify the reported size and MD5, inspect the ZIP directory for traversal, links, encryption, duplicates, unsupported methods, oversized entries, excessive expansion, and suspicious compression ratios, and extract only the media/image/metadata extensions used by dub packs. Extraction is staged beside `packs_voice` and renamed into place only after validation. Uninstall only removes a direct `packs_voice` child with this installer's matching manifest; manually installed folders are untouched.

These checks reduce the attack surface but cannot make arbitrary community media trustworthy; the UI and README retain that warning.

## Compatibility

- Protocol 8 is intentionally incompatible with earlier builds.
- Supported game builds remain Windows 0.5.1 and 0.5.2 dev-2.
- Standard Mode behavior is unchanged; it still requires the clips selected by the host to exist locally.

## Testing

- Headless Godot compile/self-test: 17 scripts compiled, 0 failures.
- Community fixtures cover catalog/detail normalization, search URL encoding and API errors, safe/unsafe ZIP paths, wrapped and flat ZIP installation, manifest discovery, guarded uninstall, long-name layout compaction, queue cancellation/retry/failure recovery, and online-download opt-in.
- Final two-peer headless smoke test completed with no `NETTEST FAIL` output on either peer. It covered handshake RPC ordering, roster manifests, two consecutive sessions, forced fresh transfer, reversible decline, interrupted-transfer resume, SHA-256 cache verification, host readiness gating, cast agreement, and synchronized watch.
- Rendered UI smoke tests at 1280×720 and 1024×720, including extremely long community titles and a 400-character archive filename.
- GameBanana browse, detail, search, queue, install, uninstall, and background-download flows were manually exercised during development.

## Known limitations

- Pack sharing and the community browser are deliberately labeled experimental.
- RAR and 7z archives still require manual installation; safe extraction is ZIP-only here.
- Community download retries restart the current archive rather than using HTTP range resume.
- The base game rescans `packs_voice` when its selector opens, so a selector already on screen must be reopened after a background install finishes.
- Extras integration is best-effort because the purchased game's scene is not stored in this repository; the main-menu and online-screen entries are the reliable paths.
